### PR TITLE
V10.0.2

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,6 @@
+## v10.0.1 <hl> 
+- Using `CONFIG.DND5E.conditionTypes` to fetch effect labels.
+- `_getMinimumDistanceBetweenTokens` should respect diagonal movement types (will make sense in the future)
+
+## v10.0.0 <hl> 
+- Initial commit

--- a/scripts/hooks.mjs
+++ b/scripts/hooks.mjs
@@ -26,12 +26,14 @@ export function _preRollSkill(actor,config,abilityId) {
   let adv = false;
   let dis = false;
   const sourceActorEffects = actor.effects.filter(eff=>!eff.disabled);
+  if (sourceActorEffects.length === 0) return true;
 //Exhaustion 1-5
-  if ([CONFIG.DND5E.conditionTypes.exhaustion+" 1", CONFIG.DND5E.conditionTypes.exhaustion+" 2", CONFIG.DND5E.conditionTypes.exhaustion+" 3", CONFIG.DND5E.conditionTypes.exhaustion+" 4", CONFIG.DND5E.conditionTypes.exhaustion+" 5"].some(i=>sourceActorEffects?.find(eff=>eff.label.includes(i)))) dis = true;
+  const exhaustion = [CONFIG.DND5E.conditionTypes.exhaustion+" 1", CONFIG.DND5E.conditionTypes.exhaustion+" 2", CONFIG.DND5E.conditionTypes.exhaustion+" 3", CONFIG.DND5E.conditionTypes.exhaustion+" 4", CONFIG.DND5E.conditionTypes.exhaustion+" 5"]
+  if (getEffects(exhaustion,sourceActorEffects)) dis = true;
 //Frightened condition
-  if (sourceActorEffects?.find(eff=>eff.label === CONFIG.DND5E.conditionTypes.frightened)) dis = true;
+  if (getEffects(CONFIG.DND5E.conditionTypes.frightened, sourceActorEffects)) dis = true;
 //Poisoned condition
-  if (sourceActorEffects?.find(eff=>eff.label === CONFIG.DND5E.conditionTypes.poisoned)) dis = true;
+  if (getEffects(CONFIG.DND5E.conditionTypes.poisoned, sourceActorEffects)) dis = true;
 //totals calc
   if (adv === true && dis === false) foundry.utils.setProperty(config, "advantage", true);
   else if (adv === false && dis === true) foundry.utils.setProperty(config, "disadvantage", true);
@@ -42,12 +44,14 @@ export function _preRollAbilityTest(actor,config,abilityId) {
   let adv = false;
   let dis = false;
   const sourceActorEffects = actor.effects.filter(eff=>!eff.disabled);
+  if (sourceActorEffects.length === 0) return true;
 //Exhaustion 1-5
-  if ([CONFIG.DND5E.conditionTypes.exhaustion+" 1", CONFIG.DND5E.conditionTypes.exhaustion+" 2", CONFIG.DND5E.conditionTypes.exhaustion+" 3", CONFIG.DND5E.conditionTypes.exhaustion+" 4", CONFIG.DND5E.conditionTypes.exhaustion+" 5"].some(i=>sourceActorEffects?.find(eff=>eff.label.includes(i)))) dis = true;
+  const exhaustion = [CONFIG.DND5E.conditionTypes.exhaustion+" 1", CONFIG.DND5E.conditionTypes.exhaustion+" 2", CONFIG.DND5E.conditionTypes.exhaustion+" 3", CONFIG.DND5E.conditionTypes.exhaustion+" 4", CONFIG.DND5E.conditionTypes.exhaustion+" 5"]
+  if (getEffects(exhaustion,sourceActorEffects)) dis = true;
 //Frightened condition
-  if (sourceActorEffects?.find(eff=>eff.label === CONFIG.DND5E.conditionTypes.frightened)) dis = true;
+  if (getEffects(CONFIG.DND5E.conditionTypes.frightened, sourceActorEffects)) dis = true;
 //Poisoned condition
-  if (sourceActorEffects?.find(eff=>eff.label === CONFIG.DND5E.conditionTypes.poisoned)) dis = true;
+  if (getEffects(CONFIG.DND5E.conditionTypes.poisoned, sourceActorEffects)) dis = true;
 //totals calc
   if (adv === true && dis === false) foundry.utils.setProperty(config, "advantage", true);
   else if (adv === false && dis === true) foundry.utils.setProperty(config, "disadvantage", true);
@@ -62,34 +66,41 @@ export function _preRollAttack(item, config) {
   let singleTargetEffects;
   const singleTargetActor = game.user.targets?.first()?.actor;
   const singleTargetToken = game.user.targets?.first();
-  if (game.user.targets?.size === 1) singleTargetEffects = singleTargetActor.effects.filter(eff=>!eff.disabled);
+  if (singleTargetActor) singleTargetEffects = singleTargetActor.effects.filter(eff=>!eff.disabled);
+  if (sourceActorEffects.length === 0 && singleTargetEffects?.length === 0) return true;
+  //to-do: Warning if more than one target selected.
+//if (game.user.targets?.size === 1) singleTargetEffects = singleTargetActor.effects.filter(eff=>!eff.disabled); 
 //Blinded condition
-  if (sourceActorEffects?.find(eff=>eff.label === CONFIG.DND5E.conditionTypes.blinded)) dis = true;
-  if (singleTargetEffects?.find(eff=>eff.label === CONFIG.DND5E.conditionTypes.blinded)) adv = true;
+  if (!!sourceActorEffects && getEffects(CONFIG.DND5E.conditionTypes.blinded, sourceActorEffects)) dis = true;
+  if (!!singleTargetEffects && getEffects(CONFIG.DND5E.conditionTypes.blinded, singleTargetEffects)) adv = true;
 //Exhaustion 3-5
-  if ([CONFIG.DND5E.conditionTypes.exhaustion+" 3", CONFIG.DND5E.conditionTypes.exhaustion+" 4", CONFIG.DND5E.conditionTypes.exhaustion+" 5"].some(i=>sourceActorEffects?.find(eff=>eff.label.includes(i)))) dis = true;
+const exhaustion = [CONFIG.DND5E.conditionTypes.exhaustion+" 3", CONFIG.DND5E.conditionTypes.exhaustion+" 4", CONFIG.DND5E.conditionTypes.exhaustion+" 5"];
+  if (!!sourceActorEffects && getEffects(exhaustion, sourceActorEffects)) dis = true;
 //Frightened condition
-  if (sourceActorEffects?.find(eff=>eff.label === CONFIG.DND5E.conditionTypes.frightened)) dis = true;
+  if (!!sourceActorEffects && getEffects(CONFIG.DND5E.conditionTypes.frightened, sourceActorEffects)) dis = true;
 //Invisible condition
-  if (sourceActorEffects?.find(eff=>eff.label === CONFIG.DND5E.conditionTypes.invisible)) adv = true;
-  if (singleTargetEffects?.find(eff=>eff.label === CONFIG.DND5E.conditionTypes.invisible)) dis = true;
-//Paralysed condition.
-  if (singleTargetEffects?.find(eff=>eff.label === "Paralysed" || eff.label === CONFIG.DND5E.conditionTypes.paralyzed)) adv = true;
-//Petrified condition.
-  if (singleTargetEffects?.find(eff=>eff.label === CONFIG.DND5E.conditionTypes.petrified)) adv = true;
+  if (!!sourceActorEffects && getEffects(CONFIG.DND5E.conditionTypes.invisible, sourceActorEffects)) adv = true;
+  if (!!singleTargetEffects && getEffects(CONFIG.DND5E.conditionTypes.invisible, singleTargetEffects)) dis = true;
+//Paralyzed condition
+  if (!!singleTargetEffects && getEffects(["Paralysed",CONFIG.DND5E.conditionTypes.paralyzed], singleTargetEffects)) adv = true;
+//Petrified condition
+  if (!!singleTargetEffects && getEffects(CONFIG.DND5E.conditionTypes.petrified, singleTargetEffects)) adv = true;
 //Poisoned condition
-  if (sourceActorEffects?.find(eff=>eff.label === CONFIG.DND5E.conditionTypes.poisoned)) dis = true;
+  if (!!sourceActorEffects && getEffects(CONFIG.DND5E.conditionTypes.poisoned, sourceActorEffects)) dis = true;
 //Prone condition
-  if (singleTargetEffects?.find(eff=>eff.label === CONFIG.DND5E.conditionTypes.prone) && (item.system.actionType === "mwak" || item.system.actionType === "msak")) adv = true;
-  if (singleTargetEffects?.find(eff=>eff.label === CONFIG.DND5E.conditionTypes.prone) && (item.system.actionType === "rwak" || item.system.actionType === "rsak")) dis = true;
-  if (sourceActorEffects?.find(eff=>eff.label === CONFIG.DND5E.conditionTypes.prone)) dis = true;
+  if (!!singleTargetEffects && getEffects(CONFIG.DND5E.conditionTypes.prone, singleTargetEffects) && ["mwak","msak"].includes(item.system.actionType)) {
+    if (_getMinimumDistanceBetweenTokens(sourceActorToken,singleTargetToken)<=5) adv = true;     //mock test for thrown weapons - might revisit this later.
+    else dis = true;
+  };
+  if (!!singleTargetEffects && getEffects(CONFIG.DND5E.conditionTypes.prone, singleTargetEffects) && ["rwak","rsak"].includes(item.system.actionType)) adv = true;
+  if (!!sourceActorEffects && getEffects(CONFIG.DND5E.conditionTypes.prone, sourceActorEffects)) dis = true;
 //Restrained condition
-  if (sourceActorEffects?.find(eff=>eff.label === CONFIG.DND5E.conditionTypes.restrained)) dis = true;
-  if (singleTargetEffects?.find(eff=>eff.label === CONFIG.DND5E.conditionTypes.restrained)) adv = true;
+  if (!!sourceActorEffects && getEffects(CONFIG.DND5E.conditionTypes.restrained, sourceActorEffects)) dis = true;
+  if (!!singleTargetEffects && getEffects(CONFIG.DND5E.conditionTypes.restrained, singleTargetEffects)) adv = true;
 //Stunned condition
-  if (singleTargetEffects?.find(eff=>eff.label === CONFIG.DND5E.conditionTypes.stunned)) adv = true;
+  if (!!singleTargetEffects && getEffects(CONFIG.DND5E.conditionTypes.stunned, singleTargetEffects)) adv = true;
 //Unconscious condition
-  if (singleTargetEffects?.find(eff=>eff.label === CONFIG.DND5E.conditionTypes.unconscious)) adv = true;
+  if (!!singleTargetEffects && getEffects(CONFIG.DND5E.conditionTypes.unconscious, singleTargetEffects)) adv = true;
 //totals calc
   if (adv === true && dis === false) foundry.utils.setProperty(config, "advantage", true);
   else if (adv === false && dis === true) foundry.utils.setProperty(config, "disadvantage", true);
@@ -103,12 +114,34 @@ export function _preRollDamage(item, config) {
   let singleTargetEffects;
   const singleTargetActor = game.user.targets?.first()?.actor;
   const singleTargetToken = game.user.targets?.first();
-  if (game.user.targets?.size === 1) singleTargetEffects = singleTargetActor.effects.filter(eff=>!eff.disabled);
+  if (singleTargetActor) singleTargetEffects = singleTargetActor.effects.filter(eff=>!eff.disabled);
+  if (sourceActorEffects.length === 0 && singleTargetEffects?.length === 0) return true;
+  //to-do: Warning if more than one target selected.
+//if (game.user.targets?.size === 1) singleTargetEffects = singleTargetActor.effects.filter(eff=>!eff.disabled);
 //Paralysed condition.
-  if (singleTargetEffects?.find(eff=>eff.label === "Paralysed" || eff.label === CONFIG.DND5E.conditionTypes.paralyzed) && _getMinimumDistanceBetweenTokens(sourceActorToken,singleTargetToken)<=5) crit = true; 
+  if (!!singleTargetEffects && getEffects(["Paralysed",CONFIG.DND5E.conditionTypes.paralyzed], singleTargetEffects) && _getMinimumDistanceBetweenTokens(sourceActorToken,singleTargetToken)<=5) crit = true;
 //Unconscious condition
-  if (singleTargetEffects?.find(eff=>eff.label === "Paralysed" || eff.label === CONFIG.DND5E.conditionTypes.paralyzed) && _getMinimumDistanceBetweenTokens(sourceActorToken,singleTargetToken)<=5) crit = true; 
+  if (!!singleTargetEffects && getEffects(CONFIG.DND5E.conditionTypes.unconscious, singleTargetEffects) && _getMinimumDistanceBetweenTokens(sourceActorToken,singleTargetToken)<=5) crit = true;
 //totals calc
   if (crit) foundry.utils.setProperty(config, "critical", true);
   else return true;
+}
+
+export function _preRollDeathSave(actor, config) {
+  let adv = false;
+  let dis = false;
+  const sourceActorEffects = actor.effects.filter(eff=>!eff.disabled);
+  if (sourceActorEffects.length === 0) return true;
+//Exhaustion 3-5
+  const exhaustion = [CONFIG.DND5E.conditionTypes.exhaustion+" 3", CONFIG.DND5E.conditionTypes.exhaustion+" 4", CONFIG.DND5E.conditionTypes.exhaustion+" 5"];
+  if (!!sourceActorEffects && getEffects(exhaustion, sourceActorEffects)) dis = true;
+//totals calc
+  if (adv === true && dis === false) foundry.utils.setProperty(config, "advantage", true);
+  else if (adv === false && dis === true) foundry.utils.setProperty(config, "disadvantage", true);
+  else return true;
+}
+
+function getEffects(effectName, effects) {
+  if (typeof(effectName) === "string") effectName = [effectName];
+  return effectName.some(name => effects.some(eff=>eff.label === name));
 }

--- a/setup.mjs
+++ b/setup.mjs
@@ -3,7 +3,8 @@ import {
   _preRollSkill,
   _preRollAbilityTest,
   _preRollAttack,
-  _preRollDamage
+  _preRollDamage,
+  _preRollDeathSave
 } from "./scripts/hooks.mjs";
 
 Hooks.once("init", () => {
@@ -15,3 +16,4 @@ Hooks.on("dnd5e.preRollSkill", _preRollSkill);
 Hooks.on("dnd5e.preRollAbilityTest", _preRollAbilityTest);
 Hooks.on("dnd5e.preRollAttack", _preRollAttack);
 Hooks.on("dnd5e.preRollDamage", _preRollDamage);
+Hooks.on("dnd5e.preRollDeathSave", _preRollDeathSave);


### PR DESCRIPTION
- Melee attacks on Prone targets will have advantage when distance <=5, and disadvantage otherwise. 
   - [x] Closing https://github.com/thatlonelybugbear/automated-conditions-5e/issues/3

- Added RollDeathSaves. Exhaustion levels 3-5 will grant disadvantage of death Saves.
  - [x] Closing https://github.com/thatlonelybugbear/automated-conditions-5e/issues/4