### PR TITLE
63 notification when rolling attacks or damage setting

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+## v11.315.304.7
+Closes [63](https://github.com/thatlonelybugbear/automated-conditions-5e/issues/63) with a new setting for `AC5e targeting options`. <br><br>
+When 0 or more than 1 targets are selected, AC5e will not be able by default to calculate correctly advantageMode/damageMode as this is done based on the first of the `game.user.targets` only. There is now a setting for the GM to decide how AC5e will deal with targeting and rolling an Attack or Damage, or try to Use an Item that has an attack and Target any of the Individual target options in its details tab. The options are as follows:
+   * `From Source Only`: The advantageMode/damageMode will be calculated based on effects/conditions etc on the Source actor only (___default option___),
+   * `Do nothing`: No calculations whatsoever will take place,
+   * `Enforce targeting`: Will cancel the incoming Roll or Item use, and display a warning for the user to target `1 Target` (___Use with caution___).
+
+<hr>
 ## v11.315.304.6.8
 * Fix bug when rolling an attack and automated encumbrance is true.
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,7 @@ When 0 or more than 1 targets are selected, AC5e will not be able by default to 
    * `Do nothing`: No calculations whatsoever will take place,
    * `Enforce targeting`: Will cancel the incoming Roll or Item use, and display a warning for the user to target `1 Target` (___Use with caution___).
 
-<hr>
+
 ## v11.315.304.6.8
 * Fix bug when rolling an attack and automated encumbrance is true.
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ Fast Forwarding the rolls (holding SHIFT) will roll with advantage/disadvantage 
 - **Unconscious**: Auto fails strength/dexterity saves, grants advantage on attacks by others, crit if hit within 5ft ++ Prone
 
 # Settings added for:
-- Armor automation (default off)
+- **Armor automation (default off)**
   - Ability Checks, Saves and Attack Rolls for (STR || DEX) based rolls, if the Actor is not proficient in the equipped suit of Armor.
   - Imposes disadvantage on Stealth checks when the relevant property of the Armor is selected.
-- Range automation (default off)
+- **Range automation (default off)**
   - Attacking with a ranged weapon at long range imposes disadvantage on the roll (Long Range).
   - Attacking with a ranged weapon, when an enemy is adjacent, imposes disadvantage on the roll (Nearby Foe).
   - Attacking with a ranged weapon at a distance longer than the long range, imposes a fail on the roll (Out of Range).
@@ -53,7 +53,16 @@ Fast Forwarding the rolls (holding SHIFT) will roll with advantage/disadvantage 
   - Sharpshooter: No disadvantage when shooting at long range with
     - A flag on the Actor `flags.automated-conditions-5e.sharpShooter | Override | 1` or
     - An Item named `Sharpshooter`.
-- Show/hide roll dialog tooltips (default on)
+- **Show/hide roll dialog tooltips (default on)**
+- **Exhaustion automation (default on)**
+  - If you want to not automatically process Exhaustion conditions uncheck this. Doing so will allow for other exhaustion modules to alter exhaustion automation or your own rules.
+- **Encumbrance automation (default off)**
+  - Dnd5e v3.x system offers a setting for Encumbrance rules. If that is set to `Variant`, and you turn this AC5e setting on, ability checks, attack rolls, and saving throws that use Strength, Dexterity, or Constitution will have disadvantage.
+- **Targeting options (default From source only)**
+  - When 0 or more than 1 targets are selected, AC5e will not be able by default to calculate correctly advantageMode/damageMode as this is done based on the first of the game.user.targets only. There is now a setting for the GM to decide how AC5e will deal with targeting and rolling an Attack or Damage, or try to Use an Item that has an attack and Target any of the Individual target options in its details tab. The options are as follows:
+    - *From Source Only*: The advantageMode/damageMode will be calculated based on effects/conditions etc on the Source actor only (default option),
+    - *Do nothing*: No calculations whatsoever will take place,
+    - *Enforce targeting*: Will cancel the incoming Roll or Item use, and display a warning for the user to target 1 Target (Use with caution).
 
 # Compatibility
 - [x] Core highlights the correct buttons to press depending on the conditions on attacker and target, and Fast Forwards correctly.

--- a/lang/en.json
+++ b/lang/en.json
@@ -12,5 +12,10 @@
 	"AC5E.MultipleTargetsAttackWarn": "Automated Conditions 5e: You are attacking multiple targets and that is not supported. The Roll results can be skewed.",
 	"AC5E.NoTargetsAttackWarn": "Automated Conditions 5e: You are have no targets selected when attacking. Please always target if you want AC5E to suggest advantageModes properly",
 	"AC5E.MultipleTargetsDamageWarn": "Automated Conditions 5e: You are damaging multiple targets and that is not supported. The Roll results can be skewed.",
-	"AC5E.NoTargetsDamageWarn": "Automated Conditions 5e: You are have no targets selected when rolling damage. Please always target if you want AC5E to suggest roll modes properly"
+	"AC5E.NoTargetsDamageWarn": "Automated Conditions 5e: You are have no targets selected when rolling damage. Please always target if you want AC5E to suggest roll modes properly",
+	"AC5E.TargetingChoicesNone": "Do nothing",
+	"AC5E.TargetingChoicesSource": "From source only",
+	"AC5E.TargetingChoicesForce": "Enforce targeting",
+	"AC5E.TargetingName": "AC5e targeting options",
+	"AC5E.TargetingHint": "If none or multiple target(s) selected when user rolls for Attack or Damage, AC5e will: 'Do nothing': No advantageMode/damageMode calculations for the incoming roll; 'From source only': advantageMode/damageMode based on any source Actor effects; 'Enforce Targeting':  Cancel roll and ask for targets before rolling again (Use with caution);"
 }

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
     "id": "automated-conditions-5e",
     "title": "Automated Conditions 5e",
     "description": "A small module for Foundry VTT that tries to automate some rolling aspects of the common 5e Conditions.",
-    "version": "11.315.304.6.8",
+    "version": "11.315.304.7",
     "authors": [
         {
             "name": "thatlonelybugbear",
@@ -48,6 +48,6 @@
     "url": "https://github.com/thatlonelybugbear/automated-conditions-5e",
     "license": "https://raw.githubusercontent.com/thatlonelybugbear/automated-conditions-5e/main/LICENSE",
     "manifest": "https://github.com/thatlonelybugbear/automated-conditions-5e/releases/latest/download/module.json",
-    "download": "https://github.com/thatlonelybugbear/automated-conditions-5e/releases/download/v11.315.304.6.8/module.zip",
+    "download": "https://github.com/thatlonelybugbear/automated-conditions-5e/releases/download/v11.315.304.7/module.zip",
     "changelog": "https://raw.githubusercontent.com/thatlonelybugbear/automated-conditions-5e/main/Changelog.md"
 }

--- a/scripts/ac5e-helpers.mjs
+++ b/scripts/ac5e-helpers.mjs
@@ -53,7 +53,7 @@ export function _i18nConditions(name) {
 }
 
 export function _localize(string) {
-	return game.i18n.translations.DND5E[string] ?? game.i18n.localize[string];
+	return game.i18n.translations.DND5E[string] ?? game.i18n.localize(string);
 }
 
 export function _hasStatuses(actor, statuses) {

--- a/scripts/ac5e-helpers.mjs
+++ b/scripts/ac5e-helpers.mjs
@@ -52,8 +52,8 @@ export function _i18nConditions(name) {
 	);
 }
 
-export function _i18n5e(string) {
-	return game.i18n.translations.DND5E[string];
+export function _localize(string) {
+	return game.i18n.translations.DND5E[string] ?? game.i18n.localize[string];
 }
 
 export function _hasStatuses(actor, statuses) {

--- a/scripts/ac5e-hooks.mjs
+++ b/scripts/ac5e-hooks.mjs
@@ -28,11 +28,6 @@ const getConfig = (config) => {
 	};
 };
 
-const targets = game.user.targets;
-const targetsSize = targets?.size;
-const singleTargetToken = targets?.first(); //to-do: refactor for dnd5e 3.x target in messageData; flags.dnd5e.targets[0].uuid Actor5e#uuid not entirely useful.
-const singleTargetActor = singleTargetToken?.actor;
-
 export function _preRollAbilitySave(actor, config, abilityId) {
 	if (config.event?.altKey || config.event?.ctrlKey) return true; //bail out if someone presses keys for adv/dis ff roll. Need to get the keys from MidiQOL for integration
 	//to-do: getSetting for event overriding any calcs or continue
@@ -206,6 +201,10 @@ export function _preRollAttack(item, config) {
 	ac5eConfig.advantage.target = [];
 	ac5eConfig.disadvantage.target = [];
 	const sourceToken = canvas.tokens.get(sourceTokenID); //Token5e
+	const targets = game.user?.targets;
+	const targetsSize = targets?.size;
+	const singleTargetToken = targets?.first(); //to-do: refactor for dnd5e 3.x target in messageData; flags.dnd5e.targets[0].uuid Actor5e#uuid not entirely useful.
+	const singleTargetActor = singleTargetToken?.actor;
 	if (targetsSize != 1) {
 		//to-do: Think about more than one targets
 		if (
@@ -366,6 +365,10 @@ export function _preRollDamage(item, config) {
 	let change = false;
 	const ac5eConfig = getConfig(config);
 	const sourceToken = canvas.tokens.get(sourceTokenID);
+	const targets = game.user?.targets;
+	const targetsSize = targets?.size;
+	const singleTargetToken = targets?.first(); //to-do: refactor for dnd5e 3.x target in messageData; flags.dnd5e.targets[0].uuid Actor5e#uuid not entirely useful.
+	const singleTargetActor = singleTargetToken?.actor;
 	if (targetsSize != 1) {
 		//to-do: Think about more than one targets
 		if (
@@ -517,6 +520,8 @@ export function _renderDialog(dialog, elem) {
 
 export function _preUseItem(item) /*, config, options)*/ {
 	//will cancel the Item use if the Item needs 1 target to function properly and none or more than 1 are selected.
+	const targets = game.user?.targets;
+	const targetsSize = targets?.size;
 	if (settings.needsTarget == 'force')
 		return hasValidTargets(item, targetsSize, 'pre', 'enforce');
 }

--- a/scripts/ac5e-hooks.mjs
+++ b/scripts/ac5e-hooks.mjs
@@ -3,7 +3,7 @@ import {
 	_getDistance,
 	_hasAppliedEffects,
 	_hasStatuses,
-	_i18n5e,
+	_localize,
 	_i18nConditions,
 	_autoArmor,
 	_autoEncumbrance,
@@ -73,7 +73,7 @@ export function _preRollAbilitySave(actor, config, abilityId) {
 	) {
 		ac5eConfig.disadvantage = [
 			...ac5eConfig.disadvantage,
-			`${_i18n5e('Armor')} (${_i18n5e('NotProficient')})`,
+			`${_localize('Armor')} (${_localize('NotProficient')})`,
 		];
 		change = true;
 	}
@@ -117,14 +117,14 @@ export function _preRollSkill(actor, config, skillId) {
 		if (['dex', 'str'].includes(defaultAbility) && !_autoArmor(actor, 'prof')) {
 			ac5eConfig.disadvantage = [
 				...ac5eConfig.disadvantage,
-				`${_i18n5e('Armor')} (${_i18n5e('NotProficient')})`,
+				`${_localize('Armor')} (${_localize('NotProficient')})`,
 			];
 			change = true;
 		}
 		if (skillId === 'ste' && _autoArmor(actor, 'stealth')) {
 			ac5eConfig.disadvantage = [
 				...ac5eConfig.disadvantage,
-				`${_i18n5e('Armor')} (${_i18n5e('ItemEquipmentStealthDisav')})`,
+				`${_localize('Armor')} (${_localize('ItemEquipmentStealthDisav')})`,
 			];
 			change = true;
 		}
@@ -170,7 +170,7 @@ export function _preRollAbilityTest(actor, config, abilityId) {
 	) {
 		ac5eConfig.disadvantage = [
 			...ac5eConfig.disadvantage,
-			`${_i18n5e('Armor')} (${_i18n5e('NotProficient')})`,
+			`${_localize('Armor')} (${_localize('NotProficient')})`,
 		];
 		change = true;
 	}
@@ -306,7 +306,7 @@ export function _preRollAttack(item, config) {
 			}
 			if (range === 'long') {
 				ac5eConfig.disadvantage.source = ac5eConfig.disadvantage.source.concat(
-					_i18n5e('RangeLong')
+					_localize('RangeLong')
 				);
 				change = true;
 			}
@@ -325,7 +325,7 @@ export function _preRollAttack(item, config) {
 		!_autoArmor(sourceActor, 'prof')
 	) {
 		ac5eConfig.disadvantage.source = ac5eConfig.disadvantage.source.concat(
-			`${_i18n5e('Armor')} (${_i18n5e('NotProficient')})`
+			`${_localize('Armor')} (${_localize('NotProficient')})`
 		);
 		change = true;
 	}
@@ -453,26 +453,26 @@ export function _renderDialog(dialog, elem) {
 	let tooltip = '<center><strong>Automated Conditions 5e</strong></center>';
 	if (getConfigAC5E.critical.length)
 		tooltip = tooltip.concat(
-			`<br><span style="display: block; text-align: left;">${_i18n5e(
+			`<br><span style="display: block; text-align: left;">${_localize(
 				'Critical'
 			)}: ${getConfigAC5E.critical.join(', ')}</span>`
 		);
 	if (getConfigAC5E.advantage?.length)
 		tooltip = tooltip.concat(
-			`<br><span style="display: block; text-align: left;">${_i18n5e(
+			`<br><span style="display: block; text-align: left;">${_localize(
 				'Advantage'
 			)}: ${getConfigAC5E.advantage.join(', ')}</span>`
 		);
 	if (getConfigAC5E.disadvantage?.length)
 		tooltip = tooltip.concat(
-			`<br><span style="display: block; text-align: left;">${_i18n5e(
+			`<br><span style="display: block; text-align: left;">${_localize(
 				'Disadvantage'
 			)}: ${getConfigAC5E.disadvantage.join(', ')}</span>`
 		);
 	if (getConfigAC5E.fail) tooltip = tooltip.concat(`<br>${getConfigAC5E.fail}`);
 	if (getConfigAC5E.advantage?.source?.length)
 		tooltip = tooltip.concat(
-			`<br><span style="display: block; text-align: left;">Attacker ${_i18n5e(
+			`<br><span style="display: block; text-align: left;">Attacker ${_localize(
 				'Advantage'
 			)
 				.substring(0, 3)
@@ -482,9 +482,9 @@ export function _renderDialog(dialog, elem) {
 		);
 	if (getConfigAC5E.advantage?.target?.length)
 		tooltip = tooltip.concat(
-			`<br><span style="display: block; text-align: left;">${_i18n5e(
+			`<br><span style="display: block; text-align: left;">${_localize(
 				'Target'
-			)} grants ${_i18n5e('Advantage')
+			)} grants ${_localize('Advantage')
 				.substring(0, 3)
 				.toLocaleLowerCase()}: ${getConfigAC5E.advantage.target.join(
 				', '
@@ -492,7 +492,7 @@ export function _renderDialog(dialog, elem) {
 		);
 	if (getConfigAC5E.disadvantage?.source?.length)
 		tooltip = tooltip.concat(
-			`<br><span style="display: block; text-align: left;">Attacker ${_i18n5e(
+			`<br><span style="display: block; text-align: left;">Attacker ${_localize(
 				'Disadvantage'
 			)
 				.substring(0, 3)
@@ -502,9 +502,9 @@ export function _renderDialog(dialog, elem) {
 		);
 	if (getConfigAC5E.disadvantage?.target?.length)
 		tooltip = tooltip.concat(
-			`<br><span style="display: block; text-align: left;">${_i18n5e(
+			`<br><span style="display: block; text-align: left;">${_localize(
 				'Target'
-			)} grants ${_i18n5e('Disadvantage')
+			)} grants ${_localize('Disadvantage')
 				.substring(0, 3)
 				.toLocaleLowerCase()}: ${getConfigAC5E.disadvantage.target.join(
 				', '

--- a/scripts/ac5e-hooks.mjs
+++ b/scripts/ac5e-hooks.mjs
@@ -210,12 +210,12 @@ export function _preRollAttack(item, config) {
 		//to-do: Think about more than one targets
 		if (
 			settings.needsTarget == 'force' &&
-			!hasValidTargets(item, targetsSize, 'enforce')
+			!hasValidTargets(item, targetsSize, 'attack', 'enforce')
 		)
 			return false;
 		if (
 			settings.needsTarget == 'none' &&
-			!hasValidTargets(item, targetsSize, 'console')
+			!hasValidTargets(item, targetsSize, 'attack', 'console')
 		)
 			return true;
 	}
@@ -370,12 +370,12 @@ export function _preRollDamage(item, config) {
 		//to-do: Think about more than one targets
 		if (
 			settings.needsTarget == 'force' &&
-			!hasValidTargets(item, targetsSize, 'enforce')
+			!hasValidTargets(item, targetsSize, 'damage', 'enforce')
 		)
 			return false;
 		if (
 			settings.needsTarget == 'none' &&
-			!hasValidTargets(item, targetsSize, 'console')
+			!hasValidTargets(item, targetsSize, 'damage', 'console')
 		)
 			return true;
 	}
@@ -518,29 +518,36 @@ export function _renderDialog(dialog, elem) {
 export function _preUseItem(item) /*, config, options)*/ {
 	//will cancel the Item use if the Item needs 1 target to function properly and none or more than 1 are selected.
 	if (settings.needsTarget == 'force')
-		return hasValidTargets(item, targetsSize, 'enforce');
+		return hasValidTargets(item, targetsSize, 'pre', 'enforce');
 }
 
-function hasValidTargets(item, size, warn = false) {
+function hasValidTargets(item, size, type = 'attack', warn = false) {
 	//will return true if the Item has an attack roll and targets are correctly set and selected, or false otherwise.
-	//for when settings.needsTarget == 'force'
+	//type of hook, 'attack', 'roll'  ; seems that there is no need for a 'pre'
 	if (
 		item.hasAttack &&
 		(item.hasIndividualTarget ||
 			(!item.hasIndividualTarget && !item.hasTarget)) &&
 		size != 1
 	) {
-		sizeWarnings(size, warn);
+		sizeWarnings(size, type, warn);
 		return false;
 	} else return true;
 }
 
-function sizeWarnings(size, warn = false) {
-	const stringToDisplay = size
-		? _localize('AC5E.MultipleTargetsAttackWarn')
-		: _localize('AC5E.NoTargetsAttackWarn');
-	if (['console', 'enforce'].includes(warn)) console.warn(stringToDisplay);
-	if (warn == 'enforce') ui.notifications.warn(stringToDisplay);
+function sizeWarnings(size, type, warn = false) {
+	//size, by this point, can be either false or >1 so no need for other checks
+	//type for now can be 'damage' or 'attack'/'pre'
+	const translationString =
+		type == 'damage'
+			? size
+				? _localize('AC5E.MultipleTargetsDamageWarn')
+				: _localize('AC5E.NoTargetsDamageWarn')
+			: size
+			? _localize('AC5E.MultipleTargetsAttackWarn')
+			: _localize('AC5E.NoTargetsAttackWarn');
+	if (['console', 'enforce'].includes(warn)) console.warn(translationString);
+	if (warn == 'enforce') ui.notifications.warn(translationString);
 }
 
 /*

--- a/scripts/ac5e-main.mjs
+++ b/scripts/ac5e-main.mjs
@@ -5,6 +5,7 @@ import {
 	_preRollAttack,
 	_preRollDamage,
 	_preRollDeathSave,
+	_preUseItem,
 	_renderDialog,
 	/*_rollAttack*/
 } from './ac5e-hooks.mjs';
@@ -19,6 +20,7 @@ Hooks.once('init', () => {
 	const preRollDamage = Hooks.on('dnd5e.preRollDamage', _preRollDamage);
 	const preRollDeathSave = Hooks.on('dnd5e.preRollDeathSave',	_preRollDeathSave);
 	const preRollSkill = Hooks.on('dnd5e.preRollSkill', _preRollSkill);
+	const preUseItem = Hooks.on('dnd5e.preUseItem', _preUseItem);
 	const renderDialog = Hooks.on('renderDialog', _renderDialog);
 	console.warn(  //to-do: add rollAttack: ${rollAttack} when/if it is enabled
 		`Bugbear's Automated Conditions for 5e added the following dnd5e hooks:
@@ -28,6 +30,7 @@ Hooks.once('init', () => {
 		preRollDamage: ${preRollDamage}
 		preRollDeathSave: ${preRollDeathSave}
 		preRollSkill: ${preRollSkill}
+  		preUseItem: ${preUseItem}
 		renderDialog: ${renderDialog}`
 	);
 });

--- a/scripts/ac5e-settings.mjs
+++ b/scripts/ac5e-settings.mjs
@@ -81,9 +81,9 @@ export default class Settings {
 			default: 'source',
 			type: String,
 			choices: {
-				source: 'Only Source',
-				none: 'Do Nothing',
-				force: 'Enforce Targeting'
+				source: 'AC5E.TargetingChoicesSource',
+				none: 'AC5E.TargetingChoicesNone',
+				force: 'AC5E.TargetingChoicesForce'
 			}
 		});
 	}

--- a/scripts/ac5e-settings.mjs
+++ b/scripts/ac5e-settings.mjs
@@ -52,7 +52,7 @@ export default class Settings {
 				name: 'AC5E.AutoRangedAttacksName',
 				hint: 'AC5E.AutoRangedAttacksHint',
 				scope: 'world',
-				config: true,
+				config: false,
 				default: false,
 				type: Boolean,
 			}

--- a/scripts/ac5e-settings.mjs
+++ b/scripts/ac5e-settings.mjs
@@ -7,6 +7,7 @@ export default class Settings {
 	static AUTOMATE_RANGED_ATTACKS = 'autoRangedAttacks';
 	static AUTOMATE_EXHAUSTION = 'autoExhaustion'; //to-do: add module solution for dndone exhaustion.
 	static AUTOMATE_ENCUMBRANCE = 'autoEncumbrance';
+	static TARGETING = 'targeting';
 
 	registerSettings() {
 		this._registerWorldSettings();
@@ -72,6 +73,19 @@ export default class Settings {
 			default: false,
 			type: Boolean,
 		});
+		game.settings.register(Constants.MODULE_ID, Settings.TARGETING, {
+			name: 'AC5E.TargetingName',
+			hint: 'AC5E.TargetingHint',
+			scope: 'world',
+			config: true,
+			default: 'source',
+			type: String,
+			choices: {
+				source: 'Only Source',
+				none: 'Do Nothing',
+				force: 'Enforce Targeting'
+			}
+		});
 	}
 	get dialogTooltips() {
 		return game.settings.get(
@@ -99,5 +113,8 @@ export default class Settings {
 			game.settings.get('dnd5e', 'encumbrance') == 'variant' &&
 			game.settings.get(Constants.MODULE_ID, Settings.AUTOMATE_ENCUMBRANCE)
 		);
+	}
+	get needsTarget() {
+		return game.settings.get(CONSTANT.MODULE_ID, Settings.TARGETING);
 	}
 }

--- a/scripts/ac5e-settings.mjs
+++ b/scripts/ac5e-settings.mjs
@@ -115,6 +115,6 @@ export default class Settings {
 		);
 	}
 	get needsTarget() {
-		return game.settings.get(CONSTANT.MODULE_ID, Settings.TARGETING);
+		return game.settings.get(Constants.MODULE_ID, Settings.TARGETING);
 	}
 }


### PR DESCRIPTION
Closes #63 
- Adds a setting for how to handle targeting
- Creates a notification warning only if the setting is set to `Enforce Targeting`
- Console warns in the setting is `Enforce Targeting` or `From source only`