### PR TITLE
125 bug non proficient with shields not being triggered

### DIFF
--- a/scripts/ac5e-helpers.mjs
+++ b/scripts/ac5e-helpers.mjs
@@ -189,10 +189,12 @@ export function _autoArmor(actor) {
 			  )
 			? 'AC5E.Equipment'
 			: false,
-		notProficientArmor:
-			!!hasArmor && !hasArmor.system.proficient && !hasArmor.system.prof.multiplier,
-		notProficientShield:
-			!!hasShield && !hasShield.system.proficient && !hasShield.system.prof.multiplier,
+		notProficient:
+			!!hasArmor && !hasArmor.system.proficient && !hasArmor.system.prof.multiplier
+			? 'Armor' 
+			: !!hasShield && !hasShield.system.proficient && !hasShield.system.prof.multiplier
+			? 'Shield'
+			: false,
 	};
 }
 

--- a/scripts/ac5e-helpers.mjs
+++ b/scripts/ac5e-helpers.mjs
@@ -176,6 +176,7 @@ export function _findNearby(
 export function _autoArmor(actor) {
 	if (!actor) return {};
 	const hasArmor = actor.armor;
+	const hasShield = actor.shield;
 	return {
 		hasStealthDisadvantage: hasArmor?.system.properties.has(
 			'stealthDisadvantage'
@@ -188,8 +189,10 @@ export function _autoArmor(actor) {
 			  )
 			? 'AC5E.Equipment'
 			: false,
-		notProficient:
+		notProficientArmor:
 			!!hasArmor && !hasArmor.system.proficient && !hasArmor.system.prof.multiplier,
+		notProficientShield:
+			!!hasShield && !hasShield.system.proficient && !hasShield.system.prof.multiplier,
 	};
 }
 

--- a/scripts/ac5e-helpers.mjs
+++ b/scripts/ac5e-helpers.mjs
@@ -193,7 +193,7 @@ export function _autoArmor(actor) {
 			!!hasArmor && !hasArmor.system.proficient && !hasArmor.system.prof.multiplier
 			? 'Armor' 
 			: !!hasShield && !hasShield.system.proficient && !hasShield.system.prof.multiplier
-			? 'Shield'
+			? 'EquipmentShield'
 			: false,
 	};
 }

--- a/scripts/ac5e-helpers.mjs
+++ b/scripts/ac5e-helpers.mjs
@@ -1,4 +1,4 @@
-import Constants from './ac5e-constants.mjs';
+ import Constants from './ac5e-constants.mjs';
 import Settings from './ac5e-settings.mjs';
 
 const settings = new Settings();
@@ -178,10 +178,11 @@ export function _autoArmor(actor) {
 	const hasArmor = actor.armor;
 	const hasShield = actor.shield;
 	return {
-		hasStealthDisadvantage: hasArmor?.system.properties.has(
-			'stealthDisadvantage'
-		)
+		hasStealthDisadvantage: 
+			hasArmor?.system.properties.has('stealthDisadvantage')
 			? 'Armor'
+			: hasShield?.system.properties.has('stealthDisadvantage')
+			? 'EquipmentShield'
 			: actor.itemTypes.equipment.some(
 					(item) =>
 						item.system.equipped &&

--- a/scripts/ac5e-hooks.mjs
+++ b/scripts/ac5e-hooks.mjs
@@ -424,7 +424,7 @@ export function _preRollAttack(item, config) {
 		_autoArmor(sourceActor).notProficient
 	) {
 		ac5eConfig.disadvantage.source = ac5eConfig.disadvantage.source.concat(
-			`${_localize(_autoArmor(actor).notProficient)} (${_localize('NotProficient')})`
+			`${_localize(_autoArmor(sourceActor).notProficient)} (${_localize('NotProficient')})`
 		);
 		change = true;
 	}
@@ -757,7 +757,7 @@ export function _preUseItem(item, config, options) {
 		_autoArmor(sourceActor).notProficient
 	) {
 		ac5eConfig.disadvantage.source = ac5eConfig.disadvantage.source.concat(
-			`${_localize(_autoArmor(actor).notProficient)} (${_localize('NotProficient')})`
+			`${_localize(_autoArmor(sourceActor).notProficient)} (${_localize('NotProficient')})`
 		);
 		change = true;
 	}

--- a/scripts/ac5e-hooks.mjs
+++ b/scripts/ac5e-hooks.mjs
@@ -75,7 +75,7 @@ export function _preRollAbilitySave(actor, config, abilityId) {
 	) {
 		ac5eConfig.disadvantage = [
 			...ac5eConfig.disadvantage,
-			`${_localize('Armor')} (${_localize('NotProficient')})`,
+			`${_localize(_autoArmor(actor).notProficient)} (${_localize('NotProficient')})`,
 		];
 		change = true;
 	}
@@ -121,7 +121,7 @@ export function _preRollSkill(actor, config, skillId) {
 		) {
 			ac5eConfig.disadvantage = [
 				...ac5eConfig.disadvantage,
-				`${_localize('Armor')} (${_localize('NotProficient')})`,
+				`${_localize(_autoArmor(actor).notProficient)} (${_localize('NotProficient')})`,
 			];
 			change = true;
 		}
@@ -175,7 +175,7 @@ export function _preRollAbilityTest(actor, config, abilityId) {
 	) {
 		ac5eConfig.disadvantage = [
 			...ac5eConfig.disadvantage,
-			`${_localize('Armor')} (${_localize('NotProficient')})`,
+			`${_localize(_autoArmor(actor).notProficient)} (${_localize('NotProficient')})`,
 		];
 		change = true;
 	}
@@ -424,7 +424,7 @@ export function _preRollAttack(item, config) {
 		_autoArmor(sourceActor).notProficient
 	) {
 		ac5eConfig.disadvantage.source = ac5eConfig.disadvantage.source.concat(
-			`${_localize('Armor')} (${_localize('NotProficient')})`
+			`${_localize(_autoArmor(actor).notProficient)} (${_localize('NotProficient')})`
 		);
 		change = true;
 	}
@@ -757,7 +757,7 @@ export function _preUseItem(item, config, options) {
 		_autoArmor(sourceActor).notProficient
 	) {
 		ac5eConfig.disadvantage.source = ac5eConfig.disadvantage.source.concat(
-			`${_localize('Armor')} (${_localize('NotProficient')})`
+			`${_localize(_autoArmor(actor).notProficient)} (${_localize('NotProficient')})`
 		);
 		change = true;
 	}


### PR DESCRIPTION
Changed the logic of the _autoArmor() helper to return the string of `Armor` or `Shield` if the actor is not proficient with first Armor equipped and then Shield equipped, and localize the tooltip accordingly.

Closes #125 