### PR TITLE
getActivityActionType return early if activity.actionType is usable and also evaluate an associated item's actionType.

### DIFF
--- a/scripts/ac5e-helpers.mjs
+++ b/scripts/ac5e-helpers.mjs
@@ -578,6 +578,7 @@ export function _staticID(id) {
 }
 
 export function _getActionType(activity, returnClassifications = false) {
+	if (['mwak', 'msak', 'rwak', 'rsak'].includes(activity?.actionType)) return activity.actionType; //don't reinvent the wheel.
 	let actionType = activity?.attack?.type;
 	if (!actionType) return null;
 	if (returnClassifications) return actionType;

--- a/scripts/ac5e-setpieces.mjs
+++ b/scripts/ac5e-setpieces.mjs
@@ -336,7 +336,7 @@ function ac5eFlags({ sourceActor, sourceToken, targetActor, targetToken, ac5eCon
 			if (!!activityTypes[v] && activity?.type === v) return Roll.safeEval(mult + true);
 			if (!!attackClassifications[v] && activity?.attack?.type?.classification === v) return Roll.safeEval(mult + true);
 			if (!!attackModes[v] && activityAttackMode === v) return Roll.safeEval(mult + true);
-			if (!!attackTypes[v] && (activity?.attack?.type?.value === v || item?.system?.actionType === v)) return Roll.safeEval(mult + true);
+			if (!!attackTypes[v] && (activity?.attack?.type?.value === v || item?.system?.activities?.contents?.[0]?.actionType === v)) return Roll.safeEval(mult + true);
 			if (!!damageTypes[v] && activityDamageTypes(activity).includes(v)) return Roll.safeEval(mult + true);
 			if (!!deprecatedAttackTypes[v] && _getActionType(activity) === v) return Roll.safeEval(mult + true);
 			if (!!healingTypes[v] && activityDamageTypes(activity).includes(v)) return Roll.safeEval(mult + true);


### PR DESCRIPTION
`item.system.actionType` is deprecated, so we remove the system deprecation by replicating the way the system gets the actionType; `item.system.activitites.contents[0].actionType`