### PR TITLE
221 color settings were set to white white by default

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -56,6 +56,10 @@
 	"AC5E.Equipment": "Equipment",
 	"AC5E.NearbyFoe": "Nearby Foe",
 	"AC5E.ButtonColorPicker": {
+		"Enabled": {
+			"Name": "Colorful buttons",
+			"Hint": "Make your roll dialog buttons stand out. Default colors: #288bcc (background), white (text/border). Input user to use game.user.color (best for background). Input false/none/null/0 to turn off any of the available color pickers. Delete any field to fallback to defaults."
+		},
 		"Background": {
 			"Name": "🎨 Button background color",
 			"Hint": "Delete any string from the input to default to the game.user.color"

--- a/scripts/ac5e-helpers.mjs
+++ b/scripts/ac5e-helpers.mjs
@@ -635,3 +635,33 @@ export function _raceOrType(actor, dataType = 'race') {
 	if (dataType === 'all') return data;
 	else return data[dataType];
 }
+
+let tempDiv = null;
+
+export function _getValidColor(color, fallback, game) {
+    if (!color) return fallback;
+
+    const lower = color.trim().toLowerCase();
+    if (['false', 'none', 'null', '0'].includes(lower)) return null;
+    if (lower === 'user') return game && game.user && game.user.color && game.user.color.css ? game.user.color.css : fallback;
+
+    // Create a hidden element once and reuse it for optimazation
+    if (!tempDiv) {
+        tempDiv = document.createElement('div');
+        tempDiv.style.display = 'none';
+        document.body.appendChild(tempDiv);
+    }
+
+    tempDiv.style.color = color;
+    const computedColor = window.getComputedStyle(tempDiv).color;
+
+    // Convert RGB to hex if valid
+    const match = computedColor.match(/\d+/g);
+    if (match && match.length >= 3) {
+        return `#${match
+            .slice(0, 3)
+            .map((n) => parseInt(n).toString(16).padStart(2, '0'))
+            .join('')}`;
+    }
+    return fallback;
+}

--- a/scripts/ac5e-hooks.mjs
+++ b/scripts/ac5e-hooks.mjs
@@ -483,3 +483,70 @@ export async function _overtimeHazards(combat, update, options, user) {
 
 	return true;
 }
+
+export function _renderSettings(app, html, data) {
+	const $html = $(html);
+	const colorSettings = [
+		{ key: 'buttonColorBackground', default: '#288bcc' },
+		{ key: 'buttonColorBorder', default: 'white' },
+		{ key: 'buttonColorText', default: 'white' },
+	];
+
+	for (let { key, default: defaultValue } of colorSettings) {
+		const settingKey = `${Constants.MODULE_ID}.${key}`;
+		const input = $html.find(`[name="${settingKey}"]`);
+		if (input.length) {
+			let colorPicker = $('<input type="color" class="color-picker">');
+
+			const updateColorPicker = () => {
+				const val = input.val().trim().toLowerCase();
+				const resolved = _getValidColor(val);
+
+				// Remove color picker if input is falsy
+				if (resolved === false) {
+					colorPicker.hide();
+				} else {
+					if (!colorPicker || !colorPicker.parent().length) {
+						colorPicker = $('<input type="color" class="color-picker">');
+						input.after(colorPicker);
+					}
+					colorPicker.val(resolved).show();
+				}
+			};
+
+			// Sync picker -> input
+			colorPicker.on('input', function () {
+				const color = $(this).val();
+				input.val(color).trigger('change');
+			});
+
+			// Sync input -> picker
+			input.on('input', function () {
+				updateColorPicker();
+			});
+
+			// Reset to default when blank
+			input.on('blur', function () {
+				if ($(this).val().trim() === '') {
+					$(this).val(defaultValue).trigger('change');
+					updateColorPicker();
+				}
+			});
+
+			input.after(colorPicker);
+			updateColorPicker();
+		}
+	}
+
+	const toggle = $html.find(`[name="${Constants.MODULE_ID}.buttonColorEnabled"]`);
+	const updateVisibility = () => {
+		const visible = toggle.is(':checked');
+		const keysToToggle = ['buttonColorBackground', 'buttonColorBorder', 'buttonColorText'];
+		for (let key of keysToToggle) {
+			$html.find(`[data-setting-id="${Constants.MODULE_ID}.${key}"]`).toggle(visible);
+		}
+	};
+
+	updateVisibility();
+	toggle.on('change', updateVisibility);
+}

--- a/scripts/ac5e-hooks.mjs
+++ b/scripts/ac5e-hooks.mjs
@@ -1,4 +1,4 @@
-import { _activeModule, _calcAdvantageMode, _getActionType, _getDistance, _hasAppliedEffects, _hasItem, _hasStatuses, _localize, _i18nConditions, _autoArmor, _autoEncumbrance, _autoRanged, _getTooltip, _getConfig, _setAC5eProperties, _systemCheck, _hasValidTargets } from './ac5e-helpers.mjs';
+import { _activeModule, _calcAdvantageMode, _getActionType, _getDistance, _getValidColor, _hasAppliedEffects, _hasItem, _hasStatuses, _localize, _i18nConditions, _autoArmor, _autoEncumbrance, _autoRanged, _getTooltip, _getConfig, _setAC5eProperties, _systemCheck, _hasValidTargets } from './ac5e-helpers.mjs';
 import Constants from './ac5e-constants.mjs';
 import Settings from './ac5e-settings.mjs';
 import { _ac5eChecks } from './ac5e-setpieces.mjs';

--- a/scripts/ac5e-hooks.mjs
+++ b/scripts/ac5e-hooks.mjs
@@ -338,15 +338,13 @@ export function _renderHijack(hook, render, elem) {
 		} else if (hookType === 'damage') {
 			if (render.rolls?.[0]?.options?.isCritical) targetElement = elem.querySelector('button[data-action="critical"]');
 			else targetElement = elem.querySelector('button[data-action="normal"]');
-			// if (targetElement) {
-			// 	targetElement.focus(); //Critical is not focused; dnd5e issue.
-			// }
 		} else targetElement = elem[0].querySelector(`.dialog-button.${render.data.default}`);
 		if (!targetElement) return true;
 		if (settings.buttonColorEnabled) {
 			if (settings.buttonColorBackground) targetElement.style.backgroundColor = settings.buttonColorBackground;
 			if (settings.buttonColorBorder) targetElement.style.border = `1px solid ${settings.buttonColorBorder}`;
 			if (settings.buttonColorText) targetElement.style.color = settings.buttonColorText;
+			//to-do: play around with a box shadow
 			// if (game.settings.get('core', 'colorScheme') === 'light') targetElement.style.boxShadow = '1px 1px 3px rgba(0, 0, 0, 0.6), 2px 2px 6px rgba(0, 0, 0, 0.3)';
 		}
 		targetElement.classList.add('ac5e-button');

--- a/scripts/ac5e-hooks.mjs
+++ b/scripts/ac5e-hooks.mjs
@@ -338,15 +338,17 @@ export function _renderHijack(hook, render, elem) {
 		} else if (hookType === 'damage') {
 			if (render.rolls?.[0]?.options?.isCritical) targetElement = elem.querySelector('button[data-action="critical"]');
 			else targetElement = elem.querySelector('button[data-action="normal"]');
-			if (targetElement) {
-				targetElement.focus(); //Critical is not focused; dnd5e issue.
-			}
+			// if (targetElement) {
+			// 	targetElement.focus(); //Critical is not focused; dnd5e issue.
+			// }
 		} else targetElement = elem[0].querySelector(`.dialog-button.${render.data.default}`);
 		if (!targetElement) return true;
-		targetElement.style.color = settings.buttonColorText;
-		targetElement.style.backgroundColor = settings.buttonColorBackground;
-		targetElement.style.boxShadow = '1px 1px 3px rgba(0, 0, 0, 0.6), 2px 2px 6px rgba(0, 0, 0, 0.3)';
-		targetElement.style.border = `1px solid ${settings.buttonColorBorder}`;
+		if (settings.buttonColorEnabled) {
+			if (settings.buttonColorBackground) targetElement.style.backgroundColor = settings.buttonColorBackground;
+			if (settings.buttonColorBorder) targetElement.style.border = `1px solid ${settings.buttonColorBorder}`;
+			if (settings.buttonColorText) targetElement.style.color = settings.buttonColorText;
+			// if (game.settings.get('core', 'colorScheme') === 'light') targetElement.style.boxShadow = '1px 1px 3px rgba(0, 0, 0, 0.6), 2px 2px 6px rgba(0, 0, 0, 0.3)';
+		}
 		targetElement.classList.add('ac5e-button');
 		targetElement.setAttribute('data-tooltip', tooltip);
 		targetElement.focus(); //midi for some reason doesn't focus on skills with advMode. //to-do check this and why Dodging rolls FF for Dex save

--- a/scripts/ac5e-main.mjs
+++ b/scripts/ac5e-main.mjs
@@ -1,10 +1,11 @@
-import { _renderHijack, _rollFunctions, _overtimeHazards } from './ac5e-hooks.mjs';
+import { _renderHijack, _renderSettings, _rollFunctions, _overtimeHazards } from './ac5e-hooks.mjs';
 import { _autoRanged, _autoArmor, _activeModule, _getDistance, _raceOrType, _canSee } from './ac5e-helpers.mjs';
 import Constants from './ac5e-constants.mjs';
 import Settings from './ac5e-settings.mjs';
 
 Hooks.once('init', ac5eRegisterSettings);
 Hooks.once('ready', ac5eReady);
+Hooks.on('renderSettingsConfig', _renderSettings);
 
 /* SETUP FUNCTIONS */
 function ac5eRegisterSettings() {

--- a/scripts/ac5e-settings.mjs
+++ b/scripts/ac5e-settings.mjs
@@ -16,6 +16,7 @@ export default class Settings {
 	static KEYPRESS_OVERRIDES = 'keypressOverrides';
 	static DEBUG = 'debugging';
 	static MIGRATION = 'lastMigratedPoint';
+	static ColorPicker_Enabled = 'buttonColorEnabled';
 	static ColorPicker_Background = 'buttonColorBackground';
 	static ColorPicker_Border = 'buttonColorBorder';
 	static ColorPicker_Text = 'buttonColorText';
@@ -47,7 +48,38 @@ export default class Settings {
 			default: true,
 			type: Boolean,
 		});
-
+		game.settings.register(Constants.MODULE_ID, Settings.ColorPicker_Enabled, {
+			name: 'AC5E.ButtonColorPicker.Enabled.Name',
+			hint: 'AC5E.ButtonColorPicker.Enabled.Hint',
+			scope: 'client',
+			config: true,
+			default: '#288bcc',
+			type: Boolean,
+		});
+		game.settings.register(Constants.MODULE_ID, Settings.ColorPicker_Background, {
+			name: 'AC5E.ButtonColorPicker.Background.Name',
+			hint: 'AC5E.ButtonColorPicker.Background.Hint',
+			scope: 'client',
+			config: true,
+			default: game?.user?.color?.css,
+			type: String
+		});
+		game.settings.register(Constants.MODULE_ID, Settings.ColorPicker_Border, {
+			name: 'AC5E.ButtonColorPicker.Border.Name',
+			hint: 'AC5E.ButtonColorPicker.Border.Hint',
+			scope: 'client',
+			config: true,
+			default: 'white',
+			type: String
+		});
+		game.settings.register(Constants.MODULE_ID, Settings.ColorPicker_Text, {
+			name: 'AC5E.ButtonColorPicker.Text.Name',
+			hint: 'AC5E.ButtonColorPicker.Text.Hint',
+			scope: 'client',
+			config: true,
+			default: 'white',
+			type: String
+		});
 		game.settings.register(Constants.MODULE_ID, Settings.AUTOMATE_EXPANDED_CONDITIONS, {
 			name: 'AC5E.ExpandedConditionsName',
 			hint: 'AC5E.ExpandedConditionsHint',
@@ -151,30 +183,7 @@ export default class Settings {
 			default: false,
 			type: Boolean,
 		});
-		game.settings.register(Constants.MODULE_ID, Settings.ColorPicker_Background, {
-			name: 'AC5E.ButtonColorPicker.Background.Name',
-			hint: 'AC5E.ButtonColorPicker.Background.Hint',
-			scope: 'client',
-			config: true,
-			default: game?.user?.color?.css,
-			type: String
-		});
-		game.settings.register(Constants.MODULE_ID, Settings.ColorPicker_Border, {
-			name: 'AC5E.ButtonColorPicker.Border.Name',
-			hint: 'AC5E.ButtonColorPicker.Border.Hint',
-			scope: 'client',
-			config: true,
-			default: 'white',
-			type: String
-		});
-		game.settings.register(Constants.MODULE_ID, Settings.ColorPicker_Text, {
-			name: 'AC5E.ButtonColorPicker.Text.Name',
-			hint: 'AC5E.ButtonColorPicker.Text.Hint',
-			scope: 'client',
-			config: true,
-			default: 'white',
-			type: String
-		});
+		
 		game.settings.register(Constants.MODULE_ID, Settings.DEBUG, {
 			name: 'DEBUG',
 			scope: 'world',
@@ -236,6 +245,9 @@ export default class Settings {
 	}
 	get keypressOverrides() {
 		return game.settings.get(Constants.MODULE_ID, Settings.KEYPRESS_OVERRIDES);
+	}
+	get buttonColorEnabled() {
+		return game.settings.get(Constants.MODULE_ID, Settings.ColorPicker_Enabled);
 	}
 	get buttonColorBackground() {
 		return game.settings.get(Constants.MODULE_ID, Settings.ColorPicker_Background);


### PR DESCRIPTION
- Closes #221 by making the background default `#288bcc` (personal preference, might change)
- Introduces a setting for enabling the colorful buttons and moves all the color settings higher in the AC5e module settings for better visibility.
- Introduces passing in the color fields:
  - `user`: to use the in game user's color (best for background or border colors)
  - `false/none/null/0`: disabled the color field for that specific entry, reverting to default Foundry