### PR TITLE
Sandbox and evaluations cleanup

### DIFF
--- a/scripts/ac5e-helpers.mjs
+++ b/scripts/ac5e-helpers.mjs
@@ -857,6 +857,7 @@ export function _createEvaluationSandbox({ subject, subjectToken, opponent, oppo
 			sandbox.rollingActor.tokenElevation = subjectToken.document.elevation;
 			sandbox.rollingActor.tokenSenses = subjectToken.document.detectionModes;
 			sandbox.rollingActor.tokenUuid = subjectToken.document.uuid;
+			sandbox.tokenId = subjectToken.id;
 		};
 	};
 	if (opponent) {
@@ -868,6 +869,7 @@ export function _createEvaluationSandbox({ subject, subjectToken, opponent, oppo
 			sandbox.targetActor.tokenElevation = opponentToken.document.elevation;
 			sandbox.targetActor.tokenSenses = opponentToken.document.detectionModes;
 			sandbox.targetActor.tokenUuid = opponentToken.document.uuid;
+			sandbox.targetId = opponentToken.id;
 		};
 	};
 	if (auraActor) {
@@ -885,7 +887,7 @@ export function _createEvaluationSandbox({ subject, subjectToken, opponent, oppo
 	sandbox.activity = activity?.getRollData().activity;
 	if (activity) {
 		sandbox.activity.damageTypes = _getActivityDamageTypes(activity);
-		sandbox.activity.attackMode = options.ac5eConfig?.attackMode;
+		sandbox.activity.attackMode = options?.ac5eConfig?.attackMode;
 	        sandbox.activity.riderStatuses = _getActivityEffectsStatusRiders(activity);
 		sandbox.activity.actionType = _getActionType(activity);
 	};
@@ -898,9 +900,11 @@ export function _createEvaluationSandbox({ subject, subjectToken, opponent, oppo
 	sandbox.worldTime = game.time?.worldTime;
 	sandbox.spellLevel = options?.spellLevel;
 	sandbox.options = options;
-	if (options.skill) sandbox[options.skill] = true;
-	if (options.ability) sandbox[options.ability] = true;
-	if (options.tool) sandbox[options.tool] = true;
+	if (options?.skill) sandbox[options.skill] = true;
+	if (options?.ability) sandbox[options.ability] = true;
+	if (options?.tool) sandbox[options.tool] = true;
+	sandbox.canSee = _canSee(subjectToken, opponentToken);
+	sandbox.isSeen = _canSee(opponentToken, subjectToken);
 	
 	foundry.utils.mergeObject(sandbox, { ac5e: ac5e });
 	if (item) {

--- a/scripts/ac5e-helpers.mjs
+++ b/scripts/ac5e-helpers.mjs
@@ -910,7 +910,6 @@ export function _createEvaluationSandbox({ subject, subjectToken, opponent, oppo
 		sandbox[itemData.identifier] = true;
 		sandbox[itemData.name] = true;
 		sandbox.item.properties.filter(p=>sandbox[p] = true);
-		// sandbox[itemData.actication.type.value] = true;
 	}
 	if (activity) {
 		sandbox.riderStatuses = {};

--- a/scripts/ac5e-helpers.mjs
+++ b/scripts/ac5e-helpers.mjs
@@ -835,8 +835,7 @@ export function _ac5eSafeEval({ expression, sandbox }) {
 	}
 	let result;
 	try {
-		result = /*const evl =*/ new Function('sandbox', `with (sandbox) { return ${expression}}`)(sandbox);
-		//result = evl(sandbox);
+		result = new Function('sandbox', `with (sandbox) { return ${expression}}`)(sandbox);
 	} catch (err) {
 		result = undefined;
 	}


### PR DESCRIPTION
Closes #261 by adding: 
- `canSee`: which is true if the rolling actor can see the target actor
- `isSeen`: which is true if the target actor can seethe rolling actor

Closes #265 by cleaning up the sandbox:
- `rollingActor` holds data from::
  - `rollingActor.getRollData()`
  - `rollingToken`
- `targetActor` holds data from::
  - `targetActor.getRollData()`
  - `targetToken`
- `auraActor` if relevant holds data from::
  - `auraActor.getRollData()`
  - `auraToken`
- `item` is the `item.getRollData().item`
- `activity` is the `activity.getRollData().activity`
and other additions to be documented properly in a separate wiki entry