### PR TITLE
Update ac5e-setpieces.mjs

### DIFF
--- a/scripts/ac5e-setpieces.mjs
+++ b/scripts/ac5e-setpieces.mjs
@@ -511,9 +511,8 @@ function handleUses({ actorType, change, effect, effectDeletions, effectUpdates 
 	} else if (isOnce && isTransfer) {
 		effect.update({ disabled: true });
 	} else if (hasCount && actorType === 'subject') {
-		const string = hasCount.split('usesCount=')[1];
-		const isNumber = parseInt(string, 10);
-		const isUuid = foundry.utils.parseUuid(string);
+		const isNumber = parseInt(hasCount, 10);
+		const isUuid = foundry.utils.parseUuid(hasCount);
 
 		if (!isNaN(isNumber)) {
 			if (isNumber === 0) {


### PR DESCRIPTION
- Closes #417 
  - Adds initial logic for #414 
 
- Added `getBlacklistedKeysValue` function
- removed `radius.match` in `inAuraRadius` as now it is pre-evaluated
- added `auraTokenEvaluationData` in `effectChangesTest` for auras
- return early `includeSelf` existence in aura when `token === subjectToken`
- allow for evaluation of `radius`, `bonus`, `threshold`
- changes in `bonusReplacements()` to allow for evaluation of expressions properly
- logic for `bonus`, `radius`, `usesCount`, `threshold` using `=` or `:` 
- changes in `handleUses` to make use of `getBlacklistedKeysValue('usesCount', change.value)`
- changes to how `valuesToEvaluate` are handled for the expanded logic for using `=` or `:`