### PR TITLE
445 bug   if no damage entry when a damage roll hook is triggered it can error out

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## 13.504.4
+* Fix for error when no damage entry exists on a damage roll...
+* Updated Czech translation by [Lethrendis](https://github.com/Lethrendis/) 🤗
+
 ## 13.504.3
 * Fix for `threshold` evaluations
 * Fix type `options.damagetypes` => `options.damageTypes`

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
     "id": "automated-conditions-5e",
     "title": "Automated Conditions 5e",
     "description": "A small module for Foundry VTT that tries to automate some rolling aspects of the common 5e Conditions.",
-    "version": "13.504.3",
+    "version": "13.504.4",
     "authors": [
         {
             "name": "thatlonelybugbear",
@@ -78,6 +78,6 @@
     "url": "https://github.com/thatlonelybugbear/automated-conditions-5e",
     "license": "https://raw.githubusercontent.com/thatlonelybugbear/automated-conditions-5e/main/LICENSE",
     "manifest": "https://github.com/thatlonelybugbear/automated-conditions-5e/releases/latest/download/module.json",
-    "download": "https://github.com/thatlonelybugbear/automated-conditions-5e/releases/download/v13.504.3/module.zip",
+    "download": "https://github.com/thatlonelybugbear/automated-conditions-5e/releases/download/v13.504.4/module.zip",
     "changelog": "https://raw.githubusercontent.com/thatlonelybugbear/automated-conditions-5e/main/Changelog.md"
 }

--- a/scripts/ac5e-helpers.mjs
+++ b/scripts/ac5e-helpers.mjs
@@ -254,8 +254,10 @@ export function _getExhaustionLevel(actor, min = undefined, max = undefined) {
 
 export function _calcAdvantageMode(ac5eConfig, config, dialog, message) {
 	const { ADVANTAGE: ADV_MODE, DISADVANTAGE: DIS_MODE, NORMAL: NORM_MODE } = CONFIG.Dice.D20Roll.ADV_MODE;
-	const roll0 = config.rolls?.[0];
-	roll0.options = roll0.options || {};
+	config.rolls ??= [];
+	config.rolls[0] ??= {};
+	const roll0 = config.rolls[0];
+	roll0.options ??= {};
 	if (ac5eConfig.subject.advantage.length || ac5eConfig.opponent.advantage.length) {
 		config.advantage = true;
 		dialog.options.advantageMode = ADV_MODE;


### PR DESCRIPTION
Closes #445 