### PR TITLE
558 add a behind the scenes way to remove non 5e status effects from the token hud

### DIFF
--- a/scripts/ac5e-main.mjs
+++ b/scripts/ac5e-main.mjs
@@ -6,6 +6,7 @@ export let scopeUser;
 let daeFlags;
 
 Hooks.once('init', ac5eRegisterOnInit);
+Hooks.once('i18nInit', ac5ei18nInit);
 Hooks.once('ready', ac5eReady);
 
 /* SETUP FUNCTIONS */
@@ -16,6 +17,16 @@ function ac5eRegisterOnInit() {
 	});
 	scopeUser = game.version > 13 ? 'user' : 'client';
 	return new Settings().registerSettings();
+}
+
+function ac5ei18nInit() {
+	const settings = new Settings();
+	if (settings.removeNon5eStatuses) {
+		const basic = Object.values(CONFIG.DND5E.conditionTypes).filter(e=>!e.pseudo).map(e=>e.name.toLowerCase()).concat(['burning', 'suffocation']);
+		CONFIG.statusEffects.forEach((effect) => {
+			if (!basic.includes(effect.id)) effect.hud = false;
+		});
+	}
 }
 
 function ac5eReady() {

--- a/scripts/ac5e-settings.mjs
+++ b/scripts/ac5e-settings.mjs
@@ -24,6 +24,7 @@ export default class Settings {
 	static AUTOMATE_ENVIRONMENTAL_HAZARDS = 'autoHazards';
 	static AUTOMATE_HEAVY = 'automateHeavy';
 	static AUTOMATE_STATUSES = 'automateStatuses';
+	static REMOVE_NON5E_STATUSES = 'removeNon5eStatuses';
 
 	registerSettings() {
 		this._registerWorldSettings();
@@ -221,6 +222,13 @@ export default class Settings {
 			default: false,
 			type: Boolean,
 		});
+		game.settings.register(Constants.MODULE_ID, Settings.REMOVE_NON5E_STATUSES, {
+			name: 'Remove non 5e statuses',
+			scope: 'world',
+			config: false,
+			default: false,
+			type: Boolean,
+		});
 	}
 	get automateStatuses() {
 		return game.settings.get(Constants.MODULE_ID, Settings.AUTOMATE_STATUSES);
@@ -293,5 +301,8 @@ export default class Settings {
 	}
 	get automateHeavy() {
 		return game.settings.get(Constants.MODULE_ID, Settings.AUTOMATE_HEAVY);
+	}
+	get removeNon5eStatuses() {
+		return game.settings.get(Constants.MODULE_ID, Settings.REMOVE_NON5E_STATUSES);
 	}
 }


### PR DESCRIPTION
Closes #558 
```js
game.settings.set('automated-conditions-5e', 'removeNon5eStatuses', true);
```