### PR TITLE
Update ac5e-setpieces.mjs

### DIFF
--- a/scripts/ac5e-setpieces.mjs
+++ b/scripts/ac5e-setpieces.mjs
@@ -341,7 +341,7 @@ function ac5eFlags({ ac5eConfig, subjectToken, opponentToken }) {
 		return true;
 	};
 
-	const blacklist = new Set(['allies', 'bonus', 'enemies', 'includeself', 'itemlimited', 'modifier', 'noconcentration', 'once', 'radius', 'set', 'singleaura', 'threshold', 'usescount', 'wallsblock']);
+	const blacklist = new Set(['allies', 'bonus', 'enemies', 'includeself', 'itemlimited', 'modifier', 'noconc', 'noconcentration', 'noconcentrationcheck', 'once', 'radius', 'set', 'singleaura', 'threshold', 'usescount', 'wallsblock']);
 
 	const activityUpdates = [];
 	const activityUpdatesGM = [];


### PR DESCRIPTION
- Adds `nocon`, `noconcentration` and `noconcentrationcheck` to blacklist values
- Properly defined `noConcentration` hp updates
- Explicitly check for `once` keyword as we now can have `noconcentration` which includes once...