### PR TITLE
Refactor visibility tests to include level information

### DIFF
--- a/scripts/ac5e-systemRules.mjs
+++ b/scripts/ac5e-systemRules.mjs
@@ -373,7 +373,7 @@ function _createVisibilityTests(target, visionSource) {
 			set(value) {
 				this.point.elevation = value;
 			},
-		}
+		});
 	});
 	if (visionSource) _populateVisibilityLOS(tests, visionSource);
 	return { tests, level };

--- a/scripts/ac5e-systemRules.mjs
+++ b/scripts/ac5e-systemRules.mjs
@@ -275,8 +275,8 @@ export function canSee(source, target, status) {
 		if (_canSeeDebugEnabled()) console.warn('AC5e: No valid vision source for canSee check', { source: source?.id, target: target?.id });
 		return false;
 	}
-	const tests = _createVisibilityTests(target, visionSource);
-	const config = { tests, object: target };
+	const { tests, level } = _createVisibilityTests(target, visionSource);
+	const config = { tests, object: target, level };
 
 	const tokenDetectionModes = normalizeDetectionModes(source.document?.detectionModes ?? source.detectionModes);
 	let validModes = new Set();
@@ -358,13 +358,25 @@ function _createVisibilityTests(target, visionSource) {
 		? [[0, 0], [-t, -t], [-t, t], [t, t], [t, -t], [-t, 0], [t, 0], [0, -t], [0, t], [-t2, -t2], [-t2, t2], [t2, t2], [t2, -t2], [-t2, 0], [t2, 0], [0, -t2], [0, t2]]
 		: [[0, 0]];
 	const elevation = target.document?.elevation ?? target.elevation ?? 0;
-	const tests = offsets.map(([dx, dy]) => ({
-		point: new PIXI.Point(targetPoint.x + dx, targetPoint.y + dy),
-		elevation,
-		los: new Map(),
-	}));
+	const tokenInstance = foundry.canvas.placeables.Token;
+	const level = target instanceof tokenInstance ? canvas.scene?.levels?.get(target.document?.level) ?? canvas.level : canvas.level;
+	const tests = offsets.map(([dx, dy]) => {
+		const test = {
+			point:  { x: targetPoint.x + dx, y: targetPoint.y + dy, elevation },
+			level,
+			los: new Map(),
+		};
+		return Object.defineProperty(test, 'elevation', {
+			get() {
+				return this.point.elevation;
+			},
+			set(value) {
+				this.point.elevation = value;
+			},
+		}
+	});
 	if (visionSource) _populateVisibilityLOS(tests, visionSource);
-	return tests;
+	return { tests, level };
 }
 
 function _populateVisibilityLOS(tests, visionSource) {


### PR DESCRIPTION
```js
foundry.mjs:26452 Error: Error thrown in hooked function '' for hook 'dnd5e.preUseActivity'. Cannot read properties of undefined (reading 'id')
    at Hooks.onError (foundry.mjs:26451:24)
    at #call (foundry.mjs:26433:36)
    at Hooks.call (foundry.mjs:26412:40)
    at AttackActivity.use (mixin.mjs:222:18)
    at Item5e.use (item.mjs:715:23)
    at InventoryElement._onUseItem (inventory.mjs:851:17)
    at InventoryElement._onAction (inventory.mjs:485:31)
Caused by: TypeError: Cannot read properties of undefined (reading 'id')
    at #v (vision.mjs:88:84)
    at PointVisionSource._testLimit (vision.mjs:70:21)
    at DetectionModeDarkvision._testPoint (detection-mode.mjs:12:29)
    at foundry.mjs:181891:36
    at Array.some (<anonymous>)
    at DetectionModeDarkvision.testVisibility (foundry.mjs:181891:18)
    at canSee (ac5e-systemRules.mjs:308:31)
    at _createEvaluationSandbox (ac5e-runtimeLogic.mjs:798:19)
    at ac5eFlags (ac5e-setpieces.mjs:1140:25)
    at _ac5eChecks (ac5e-setpieces.mjs:506:15)
```