### PR TITLE
Simple Cover integration

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,10 @@
 - Fixed typed `damage.bonus` entries with `addTo=all` so each base damage part receives one matching bonus part without duplicating or dropping declared damage types.
 - Fixed typed synthetic bonus damage rolls so critical hits apply normal critical rules while `criticalStatic` bonus damage remains unchanged.
 - Fixed damage flag conditions such as `!isCritical` so they are reevaluated after AC5E opt-ins change the damage roll's critical state.
+- Added Simple Cover 5e Library Mode integration for target cover AC adjustments.
+- Prevented damage bonus and critical flags from applying to healing activities unless their condition explicitly references `isHeal`.
+- Fixed activity status-rider sandbox data when an applicable effect has no statuses collection.
+- Updated the Active Effect change-mode UI: AC5E remains available after Foundry core modes on dnd5e v5, while dnd5e v6 groups it under Bugbear's Den as Automated Conditions 5e.
 - Set Foundry v14.365 as the minimum and verified version.
 
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,14 +1,17 @@
+## 14.533.11
+
+- Added Simple Cover 5e Library Mode integration for target cover AC adjustments.
+- Prevented damage bonus and critical flags from applying to healing activities unless their condition explicitly references `isHeal`.
+  - Added `isHeal` to the Effect Value Editor autocomplete and condition assists.
+- Fixed activity status-rider sandbox data when an applicable effect has no statuses collection.
+- Updated the Active Effect change-mode UI: AC5E remains available after Foundry core modes on dnd5e v5, while dnd5e v6 will group it under Bugbear's Den as Automated Conditions 5e.
+
 ## 14.533.10
 
 - Fixed typed `damage.bonus` entries with `addTo=all` so each base damage part receives one matching bonus part without duplicating or dropping declared damage types.
 - Fixed typed synthetic bonus damage rolls so critical hits apply normal critical rules while `criticalStatic` bonus damage remains unchanged.
 - Fixed damage flag conditions such as `!isCritical` so they are reevaluated after AC5E opt-ins change the damage roll's critical state.
-- Added Simple Cover 5e Library Mode integration for target cover AC adjustments.
-- Prevented damage bonus and critical flags from applying to healing activities unless their condition explicitly references `isHeal`.
-- Fixed activity status-rider sandbox data when an applicable effect has no statuses collection.
-- Updated the Active Effect change-mode UI: AC5E remains available after Foundry core modes on dnd5e v5, while dnd5e v6 groups it under Bugbear's Den as Automated Conditions 5e.
 - Set Foundry v14.365 as the minimum and verified version.
-
 
 ## 14.533.9
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -17,6 +17,7 @@
 		"Title": "Resources & Support"
 	},
 	"AC5E.ActiveEffect.ChangeTypes.AC5E": "AC5E",
+	"AC5E.ActiveEffect.ChangeTypes.AutomatedConditions5e": "Automated Conditions 5e",
 	"AC5E.ShowTooltipsName": "Show AC5E Tooltips",
 	"AC5E.ShowTooltipsHint": "Shows AC5E tooltips in roll dialogs, chat messages, or both, explaining the reasons behind the suggested outcome.",
 	"AC5E.ShowToolTipsChoicesBoth": "Roll dialogs and chat messages",

--- a/lang/en.json
+++ b/lang/en.json
@@ -562,4 +562,3 @@
 		"ExhaustionLevels": "levels"
 	}
 }
-

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "automated-conditions-5e",
   "title": "Automated Conditions 5e",
   "description": "A Foundry VTT module that tries to automate some rolling aspects of the common 5e Conditions.",
-  "version": "14.533.10",
+  "version": "14.533.11",
   "authors": [
     {
       "name": "thatlonelybugbear",
@@ -88,6 +88,6 @@
   "url": "https://github.com/thatlonelybugbear/automated-conditions-5e",
   "license": "https://raw.githubusercontent.com/thatlonelybugbear/automated-conditions-5e/main/LICENSE",
   "manifest": "https://github.com/thatlonelybugbear/automated-conditions-5e/releases/latest/download/module.json",
-  "download": "https://github.com/thatlonelybugbear/automated-conditions-5e/releases/download/v14.533.10/module.zip",
+  "download": "https://github.com/thatlonelybugbear/automated-conditions-5e/releases/download/v14.533.11/module.zip",
   "changelog": "https://raw.githubusercontent.com/thatlonelybugbear/automated-conditions-5e/main/Changelog.md"
 }

--- a/scripts/ac5e-active-effect-change-type.mjs
+++ b/scripts/ac5e-active-effect-change-type.mjs
@@ -8,14 +8,13 @@ export function applyAc5eActiveEffectChange(targetDoc, change) {
 
 export function registerAc5eActiveEffectChangeType() {
 	if (!CONFIG?.ActiveEffect?.changeTypes) return;
+	const dnd5eV6OrNewer = foundry.utils.isNewerVersion(game.system.version, 6);
 	const config = {
-		label: 'AC5E.ActiveEffect.ChangeTypes.AC5E',
+		...(dnd5eV6OrNewer ? { group: "Bugbear's Den" } : {}),
+		label: dnd5eV6OrNewer ? 'AC5E.ActiveEffect.ChangeTypes.AutomatedConditions5e' : 'AC5E',
 		defaultPriority: 20,
 		handler: applyAc5eActiveEffectChange,
 		render: null,
 	};
 	CONFIG.ActiveEffect.changeTypes[Constants.ACTIVE_EFFECT_CHANGE_TYPE] = config;
-	CONFIG.ActiveEffect.documentClass?.CHANGE_TYPES && (CONFIG.ActiveEffect.documentClass.CHANGE_TYPES[Constants.ACTIVE_EFFECT_CHANGE_TYPE] = config);
-	globalThis.ActiveEffect?.CHANGE_TYPES && (globalThis.ActiveEffect.CHANGE_TYPES[Constants.ACTIVE_EFFECT_CHANGE_TYPE] = config);
-	foundry.documents?.ActiveEffect?.CHANGE_TYPES && (foundry.documents.ActiveEffect.CHANGE_TYPES[Constants.ACTIVE_EFFECT_CHANGE_TYPE] = config);
 }

--- a/scripts/ac5e-helpers.mjs
+++ b/scripts/ac5e-helpers.mjs
@@ -2027,6 +2027,10 @@ export function _getTooltip(ac5eConfig = {}) {
 		translationString += ` ${tooltipAlteredTargetADC} (${tooltipInitialTargetADC})`;
 		addTooltip(true, `<span style="display: block; text-align: left;">${translationString}: ${combinedTargetADC.join(', ')}</span>`);
 	}
+	if (hookType === 'attack' && ac5eConfig?.simpleCoverEntries?.length) {
+		const coverEntries = ac5eConfig.simpleCoverEntries.map((entry) => `${_localize('AC5E.ModifyAC')} ${entry.ac} (${entry.base}): ${entry.label}`);
+		addTooltip(true, `<span style="display: block; text-align: left;">${coverEntries.join(', ')}</span>`);
+	}
 	tooltip += tooltip.includes('span') ? '</div>' : `<div style="text-align:center;"><strong>${_localize('AC5E.NoChanges')}</strong></div></div>`;
 	ac5eConfig.tooltipObj ||= {};
 	ac5eConfig.tooltipObj[hookType] = tooltip;
@@ -3256,10 +3260,17 @@ export function _collectRollDamageTypes(rolls, options) {
 export function _getActivityEffectsStatusRiders(activity) {
 	const statuses = {};
 	// const riders = {};
-	activity?.applicableEffects?.forEach((effect) => {
-		Array.from(effect?.statuses).forEach((status) => (statuses[status] = true));
+	activity?.applicableEffects?.filter((effect) => {
+		Array.from(effect?.statuses ?? []).forEach((status) => (statuses[status] = true));
 		effect.flags?.dnd5e?.riders?.statuses?.forEach((rider) => (statuses[rider] = true));
 	});
+	/* For v6
+	activity?.applicableEffects?.filter((e) => {
+		const effect = e.getEffect();
+		Array.from(effect?.statuses ?? []).forEach((status) => (statuses[status] = true));
+		effect.flags?.dnd5e?.riders?.statuses?.forEach((rider) => (statuses[rider] = true));
+	});
+	*/
 	if (settings.debug) console.log('AC5E._getActivityEffectsStatusRiders:', { statuses });
 	return statuses;
 }

--- a/scripts/ac5e-main.mjs
+++ b/scripts/ac5e-main.mjs
@@ -25,7 +25,6 @@ export { createTroubleshooterSnapshot, exportTroubleshooterSnapshot, importTroub
 let daeFlags;
 const AC5E_LOCAL_BUILD_ID = 'v14.360.15042026';
 
-registerAc5eActiveEffectChangeType();
 Hooks.once('init', ac5eRegisterOnInit);
 Hooks.once('i18nInit', ac5ei18nInit);
 Hooks.once('ready', ac5eReady);

--- a/scripts/ac5e-runtimeLogic.mjs
+++ b/scripts/ac5e-runtimeLogic.mjs
@@ -276,6 +276,8 @@ export function _calcAdvantageMode(ac5eConfig, config, dialog, message, { skipSe
 		return `index:${index}`;
 	};
 	const getLiveTargetAC = (target = {}) => {
+		const embeddedAC = target?.ac;
+		if (Number.isFinite(Number(embeddedAC)) && !isForcedSentinelAC(embeddedAC)) return Number(embeddedAC);
 		const tokenUuid = target?.tokenUuid ?? target?.token?.uuid;
 		if (tokenUuid) {
 			const tokenDoc = _safeFromUuidSync(tokenUuid);
@@ -289,8 +291,6 @@ export function _calcAdvantageMode(ac5eConfig, config, dialog, message, { skipSe
 			const actorAC = actor?.system?.attributes?.ac?.value;
 			if (Number.isFinite(Number(actorAC))) return Number(actorAC);
 		}
-		const embeddedAC = target?.ac;
-		if (Number.isFinite(Number(embeddedAC)) && !isForcedSentinelAC(embeddedAC)) return Number(embeddedAC);
 		return null;
 	};
 	const hasRoll0 = Array.isArray(config.rolls) && config.rolls[0] && typeof config.rolls[0] === 'object';
@@ -1019,6 +1019,7 @@ export function _createEvaluationSandbox({ subjectToken, opponentToken, options 
 	sandbox.hasAttack = !foundry.utils.isEmpty(activity?.attack);
 	sandbox.hasDamage = !foundry.utils.isEmpty(activity?.damage?.parts);
 	sandbox.hasHealing = !foundry.utils.isEmpty(activity?.healing);
+	sandbox.isHeal = activity?.type === 'heal';
 	sandbox.hasSave = !foundry.utils.isEmpty(activity?.save);
 	sandbox.hasCheck = !foundry.utils.isEmpty(activity?.check);
 	sandbox.isAoE = activity?.target?.template?.type in CONFIG.DND5E.areaTargetTypes;

--- a/scripts/ac5e-setpieces.mjs
+++ b/scripts/ac5e-setpieces.mjs
@@ -2901,6 +2901,7 @@ function ac5eFlags({ ac5eConfig, subjectToken, opponentToken }) {
 	//special functions\\
 	function getMode({ value, sandbox, debug }) {
 		const rawValue = typeof value === 'string' ? value : String(value ?? '');
+		if (sandbox?.isHeal && sandbox?.hook === 'damage' && !/\bisHeal\b/.test(rawValue)) return false;
 		const normalizedLiteral = rawValue.trim().toLowerCase();
 		if (['1', 'true'].includes(normalizedLiteral)) return true;
 		if (['0', 'false'].includes(normalizedLiteral)) return false;

--- a/scripts/apps/ac5e-effect-value-autocomplete.mjs
+++ b/scripts/apps/ac5e-effect-value-autocomplete.mjs
@@ -70,6 +70,7 @@ const CURATED_AC5E_PATHS = [
 	'item.school',
 	'activity.school',
 	'isAoE',
+	'isHeal',
 	'isCritical',
 	'isFumble',
 	'isTurn',

--- a/scripts/apps/ac5e-effect-value-editor.mjs
+++ b/scripts/apps/ac5e-effect-value-editor.mjs
@@ -134,6 +134,7 @@ const ROLL_AWARE_ENTRIES = new Set([
 	'isConcentration',
 	'isDeathSave',
 	'isInitiative',
+	'isHeal',
 	'targetValue',
 	'isCritical',
 	'isFumble',
@@ -1481,7 +1482,7 @@ function getContextSandboxFallbackEntries(changeKey) {
 		}
 	}
 	if ((normalized.includes('attack') || normalized.includes('damage')) && !isNonDamageBonusContext(normalized)) {
-		entries.push('hasAttack', 'hasDamage', 'hasHealing', 'hasSave', 'hasCheck', 'opponentAC', 'targetOverAC');
+		entries.push('hasAttack', 'hasDamage', 'hasHealing', 'hasSave', 'hasCheck', 'isHeal', 'opponentAC', 'targetOverAC');
 	}
 	entries.push('actionType', 'attackMode', 'itemProperties', 'itemType', 'originItemProperties', 'originItemType', 'mastery');
 	return dedupe(entries);
@@ -1893,6 +1894,7 @@ function classifyContextEntry(identifier) {
 		'scaling',
 		'scaling.increase',
 		'isAoE',
+		'isHeal',
 	];
 	if (itemActivityKeys.includes(value)) return 'item-activity';
 	return 'actor';

--- a/scripts/apps/ac5e-effect-value-sheet-hooks.mjs
+++ b/scripts/apps/ac5e-effect-value-sheet-hooks.mjs
@@ -4,6 +4,8 @@ import { registerAc5eActiveEffectChangeType } from '../ac5e-active-effect-change
 import Constants from '../ac5e-constants.mjs';
 import Settings from '../ac5e-settings.mjs';
 
+const CORE_CHANGE_TYPES = new Set(['custom', 'multiply', 'add', 'subtract', 'downgrade', 'upgrade', 'override']);
+
 export function registerEffectValueEditorHooks() {
 	return Hooks.on('renderActiveEffectConfig', enhanceActiveEffectConfig);
 }
@@ -12,8 +14,10 @@ function enhanceActiveEffectConfig(app, element) {
 	const root = normalizeElement(element);
 	if (!root) return;
 	registerAc5eActiveEffectChangeType();
-	ensureAc5eChangeTypeOptions(root);
-	moveAc5eChangeTypeOptionsToBottom(root);
+	if (!foundry.utils.isNewerVersion(game.system.version, 6)) {
+		ensureAc5eChangeTypeOptions(root);
+		moveAc5eChangeTypeOptionsAfterCore(root);
+	}
 	restoreAc5eChangeTypeSelections(root);
 	if (!isDaeActiveEffectSheet(app, root)) initializeKeyAutocomplete(app, root);
 	initializeEditorButtonSync(app, root);
@@ -27,8 +31,17 @@ function ensureAc5eChangeTypeOptions(root) {
 		if (select.querySelector(`option[value="${Constants.ACTIVE_EFFECT_CHANGE_TYPE}"]`)) continue;
 		const option = document.createElement('option');
 		option.value = Constants.ACTIVE_EFFECT_CHANGE_TYPE;
-		option.textContent = game.i18n?.localize?.('AC5E.ActiveEffect.ChangeTypes.AC5E') ?? 'AC5E';
+		option.textContent = 'AC5E';
 		select.append(option);
+	}
+}
+
+function moveAc5eChangeTypeOptionsAfterCore(root) {
+	for (const select of root.querySelectorAll('select[name$=".type"]')) {
+		const option = select.querySelector(`option[value="${Constants.ACTIVE_EFFECT_CHANGE_TYPE}"]`);
+		const coreOptions = [...select.options].filter((entry) => CORE_CHANGE_TYPES.has(entry.value));
+		const lastCoreOption = coreOptions[coreOptions.length - 1];
+		if (option && lastCoreOption) lastCoreOption.after(option);
 	}
 }
 
@@ -168,13 +181,6 @@ function isAc5eChangeRow(row, input) {
 	return `${typeInput?.value ?? ''}`.trim().toLowerCase() === Constants.ACTIVE_EFFECT_CHANGE_TYPE;
 }
 
-function moveAc5eChangeTypeOptionsToBottom(root) {
-	for (const select of root.querySelectorAll('select[name$=".type"]')) {
-		const option = select.querySelector(`option[value="${Constants.ACTIVE_EFFECT_CHANGE_TYPE}"]`);
-		if (option) select.append(option);
-	}
-}
-
 function restoreAc5eChangeTypeSelections(root) {
 	for (const select of root.querySelectorAll('select[name$=".type"]')) {
 		if (`${select.value ?? ''}`.trim().toLowerCase() !== 'custom') continue;
@@ -202,5 +208,6 @@ function getChangeIndex(row, input) {
 function normalizeElement(element) {
 	if (element instanceof HTMLElement) return element;
 	if (element?.[0] instanceof HTMLElement) return element[0];
+	if (element?.element instanceof HTMLElement) return element.element;
 	return null;
 }

--- a/scripts/hooks/ac5e-hooks-render-dialog.mjs
+++ b/scripts/hooks/ac5e-hooks-render-dialog.mjs
@@ -3,6 +3,7 @@ import { doDialogAttackRender, refreshDialogAbilityState } from './ac5e-hooks-di
 import { applyOptinCriticalToDamageConfig, doDialogDamageRender } from './ac5e-hooks-dialog-damage-state.mjs';
 import { applyTargetADCStateToD20Config, rebuildOptinTargetADCState } from './ac5e-hooks-roll-target-adc.mjs';
 import { _safeFromUuidSync } from '../ac5e-helpers.mjs';
+import { applySimpleCover5eDialogTooltip } from '../integrations/ac5e-simplecover5e.mjs';
 
 function logInitialOptinFormulaDebug(stage, render, ac5eConfig) {
 	if (!globalThis.ac5e?.debug?.initialOptinFormula) return;
@@ -38,9 +39,26 @@ export function renderRollConfigDialogHijack(hook, render, elem, initialConfig, 
 	const { title, newTitle } = applyDialogTitleOverrides(render, elem, getConfigAC5E);
 	if (newTitle && title) title.textContent = newTitle;
 	if (!['both', 'dialog'].includes(deps.settings.showTooltips)) return true;
+	bindSimpleCover5eTooltip(render, elem, getConfigAC5E, deps);
 	const tooltip = deps.getTooltip(getConfigAC5E);
 	if (tooltip === '') return true;
 	return applyRenderHijackDialogButtonState(render, elem, getConfigAC5E, tooltip, deps);
+}
+
+function bindSimpleCover5eTooltip(render, elem, ac5eConfig, deps) {
+	const updateTooltip = () => {
+		const liveConfig = getDialogAc5eConfig(render, ac5eConfig);
+		if (!applySimpleCover5eDialogTooltip(liveConfig, render?.message, elem)) return;
+		const tooltip = deps.getTooltip(liveConfig);
+		for (const button of elem.querySelectorAll('.ac5e-button')) button.setAttribute('data-tooltip', tooltip);
+		if (render?.message) deps.setMessageFlagScope(render.message, deps.Constants.MODULE_ID, { tooltipObj: liveConfig.tooltipObj, hookType: liveConfig.hookType }, { merge: true });
+	};
+	updateTooltip();
+	if (elem.dataset.ac5eSimpleCoverTooltipBound) return;
+	elem.dataset.ac5eSimpleCoverTooltipBound = 'true';
+	elem.addEventListener('change', (event) => {
+		if (event.target?.matches?.(`select[name^="simplecover5e.targets."][name$=".newCover"]`)) updateTooltip();
+	});
 }
 
 function bindDialogAbilityRefresh(hook, render, elem, initialConfig, deps) {

--- a/scripts/hooks/ac5e-hooks-roll-attack.mjs
+++ b/scripts/hooks/ac5e-hooks-roll-attack.mjs
@@ -2,6 +2,7 @@ import { _getDistance, _hasValidTargets, _localize } from '../ac5e-helpers.mjs';
 import { runAc5eRollPhase } from './ac5e-hooks-roll-phase.mjs';
 import { autoRanged } from '../ac5e-systemRules.mjs';
 import { forceDialogConfigureForOptins } from './ac5e-hooks-roll-dialog-configure.mjs';
+import { applySimpleCover5eLibraryMode, applySimpleCover5eTooltip } from '../integrations/ac5e-simplecover5e.mjs';
 
 export function preRollAttack(config, dialog, message, hook, reEval, deps) {
 	if (deps.hookDebugEnabled('preRollAttackHook')) {
@@ -85,6 +86,14 @@ export function preRollAttack(config, dialog, message, hook, reEval, deps) {
 		logResolvedTargets: deps.logResolvedTargets,
 	});
 	if (invalidTargets && needsTarget !== 'source') return false;
+	applySimpleCover5eLibraryMode({
+		config,
+		message: messageForTargets,
+		messages: [message, messageForTargets],
+		activity,
+		attacker: sourceToken,
+		targets: options.targets,
+	});
 	const ac5eConfig = runAc5eRollPhase({
 		hook,
 		config,

--- a/scripts/hooks/ac5e-hooks-roll-build.mjs
+++ b/scripts/hooks/ac5e-hooks-roll-build.mjs
@@ -19,6 +19,7 @@ import { applyExplicitModeOverride, mirrorD20ModeState } from './ac5e-hooks-roll
 import { getBonusEntriesForHook } from './ac5e-hooks-roll-selections.mjs';
 import { applyTargetADCStateToD20Config, rebuildOptinTargetADCState } from './ac5e-hooks-roll-target-adc.mjs';
 import { getExistingRollOptions } from './ac5e-hooks-ui-utils.mjs';
+import { applySimpleCover5eBuildOverride, applySimpleCover5eSingleTargetTotalCover, applySimpleCover5eTooltip } from '../integrations/ac5e-simplecover5e.mjs';
 
 export function buildRollConfig(app, rollConfig, formData, index, hook, deps) {
 	if (deps.buildDebug || deps.hookDebugEnabled('buildRollConfigHook')) console.warn('AC5E._buildRollConfig', { hook, app, config: rollConfig, formData, index });
@@ -35,6 +36,8 @@ export function buildRollConfig(app, rollConfig, formData, index, hook, deps) {
 		const resolvedTargets = resolveTargets(targetMessage, messageTargets, { hook: activeHook, activity: ac5eConfig.options?.activity }, targetDeps);
 		syncTargetsToConfigAndMessage(ac5eConfig, resolvedTargets, null, targetDeps);
 	}
+	const simpleCoverTotal = activeHook === 'attack' && applySimpleCover5eBuildOverride(ac5eConfig, rollConfig, targetMessage, formData, app);
+	if (activeHook === 'attack') applySimpleCover5eTooltip(ac5eConfig, app?.message ?? targetMessage);
 	if (ac5eConfig.hookType === 'damage') {
 		const optins = getOptinsFromForm(formData);
 		setOptinSelections(ac5eConfig, optins);
@@ -57,7 +60,7 @@ export function buildRollConfig(app, rollConfig, formData, index, hook, deps) {
 	applyResolvedAbilityOverrideToRollConfig(ac5eConfig, rollConfig, activeHook);
 	if (ac5eConfig.hookType === 'attack') refreshAttackAutoRangeState(ac5eConfig, rollConfig);
 	let targetADCEntries = [];
-	if (ac5eConfig.hookType === 'attack') {
+	if (ac5eConfig.hookType === 'attack' && !simpleCoverTotal) {
 		if (ac5e?.debugTargetADC)
 			console.warn('AC5E targetADC: buildRollConfig entries', {
 				hook: ac5eConfig.hookType,
@@ -79,6 +82,7 @@ export function buildRollConfig(app, rollConfig, formData, index, hook, deps) {
 	applyExplicitModeOverride(ac5eConfig, rollConfig);
 	if (ac5eConfig.hookType === 'attack') {
 		applyTargetADCStateToD20Config(ac5eConfig, rollConfig, { syncAttackTargets: true });
+		applySimpleCover5eSingleTargetTotalCover(rollConfig, targetMessage, ac5eConfig.options?.targets);
 		if (ac5e?.debugTargetADC)
 			console.warn('AC5E targetADC: buildRollConfig target', {
 				hook: ac5eConfig.hookType,

--- a/scripts/hooks/ac5e-hooks-target-context.mjs
+++ b/scripts/hooks/ac5e-hooks-target-context.mjs
@@ -27,8 +27,8 @@ export function hydrateTargetACs(targets = [], { allowLiveFallback = true } = {}
 
 export function resolveTargets(message, messageTargets, { hook, activity } = {}, deps) {
 	const freshTargets = getTargets({ message }, deps);
-	if (Array.isArray(freshTargets) && freshTargets.length) return hydrateTargetACs(freshTargets, { allowLiveFallback: false });
-	if (Array.isArray(messageTargets) && messageTargets.length) return hydrateTargetACs(messageTargets, { allowLiveFallback: false });
+	if (Array.isArray(freshTargets) && freshTargets.length) return hydrateTargetACs(captureTargetTokenUuids(freshTargets), { allowLiveFallback: false });
+	if (Array.isArray(messageTargets) && messageTargets.length) return hydrateTargetACs(captureTargetTokenUuids(messageTargets), { allowLiveFallback: false });
 	if (hook === 'save' && activity?.target?.affects?.type === 'self') {
 		const explicitMessage = message?.document ?? message;
 		const speakerToken = explicitMessage?.speaker?.token ? canvas.tokens.get(explicitMessage.speaker.token) : null;
@@ -65,11 +65,33 @@ export function syncResolvedTargetsToMessage(message, targets, deps) {
 			foundry.utils.mergeObject(foundry.utils.duplicate(currentAc5eFlags), { optionsSnapshot: { targets: foundry.utils.duplicate(nextTargets) } }, { inplace: false })
 		:	{ optionsSnapshot: { targets: foundry.utils.duplicate(nextTargets) } };
 	try {
-		foundry.utils.setProperty(message, 'data.flags.dnd5e.targets', nextTargets);
 		foundry.utils.setProperty(message, `data.flags.${deps.Constants.MODULE_ID}`, nextAc5eFlags);
 	} catch (_err) {
 		// ignore immutable message-like payloads
 	}
+}
+
+function captureTargetTokenUuids(targets) {
+	if (!game.user?.targets?.size) return targets;
+	const selectedByActorUuid = new Map();
+	for (const token of game.user.targets) {
+		const uuid = token?.actor?.uuid;
+		if (!uuid) continue;
+		const selected = selectedByActorUuid.get(uuid) ?? [];
+		selected.push(token);
+		selectedByActorUuid.set(uuid, selected);
+	}
+	const targetCountByActorUuid = new Map();
+	for (const target of targets) {
+		if (!target?.uuid) continue;
+		targetCountByActorUuid.set(target.uuid, (targetCountByActorUuid.get(target.uuid) ?? 0) + 1);
+	}
+	return targets.map((target) => {
+		if (!target?.uuid || target?.tokenUuid || targetCountByActorUuid.get(target.uuid) !== 1) return target;
+		const selected = selectedByActorUuid.get(target.uuid);
+		if (selected?.length !== 1) return target;
+		return { ...target, tokenUuid: selected[0].document?.uuid };
+	});
 }
 
 export function getAssociatedRollTargets(originatingMessageId, activityType, messageLike, deps) {

--- a/scripts/integrations/ac5e-simplecover5e.mjs
+++ b/scripts/integrations/ac5e-simplecover5e.mjs
@@ -1,0 +1,160 @@
+const MODULE_ID = 'simplecover5e';
+const TOTAL_COVER_AC = 999;
+const COVER_BONUSES = Object.freeze({ none: 0, half: 2, threeQuarters: 5, total: null });
+
+
+export function applySimpleCover5eLibraryMode({ config, message, messages = [], activity, attacker, targets } = {}) {
+	const api = game.modules.get(MODULE_ID)?.api;
+	if (_activeModule('midi-qol') || !api?.getCoverForTargets || !api.getLibraryMode?.() || !attacker || !Array.isArray(targets) || !targets.length) return;
+	const targetMessages = [...new Set([message, ...messages])].filter(Boolean);
+	const targetTokens = targets.map((target) => fromUuidSync(target?.tokenUuid)?.object).filter(Boolean);
+	if (!targetTokens.length) return;
+	const results = api.getCoverForTargets({
+		activity,
+		attacker,
+		targets: targetTokens,
+		losCheck: !!game.settings.get(MODULE_ID, 'losCheck'),
+		includeEmbeddedCover: true,
+	});
+	const coverTargets = [];
+	for (const result of results) {
+		const actor = result?.target?.actor;
+		const tokenUuid = result?.target?.document?.uuid;
+		if (!actor) continue;
+		const cover = result?.result?.cover ?? 'none';
+		const bonus = result?.result?.bonus ?? COVER_BONUSES[cover];
+		const target = targets.find((entry) => entry?.tokenUuid === tokenUuid);
+		const ac = bonus === null ? TOTAL_COVER_AC : Number(actor.system?.attributes?.ac?.value ?? 0) + bonus;
+		if (target) target.ac = ac;
+		for (const targetMessage of targetMessages) setMessageTargetAC(targetMessage, actor.uuid, ac);
+		coverTargets.push({ newCover: null, originalCover: cover, uuid: actor.uuid, tokenUuid });
+	}
+	if (!coverTargets.length) return;
+	for (const targetMessage of targetMessages) foundry.utils.setProperty(targetMessage, `data.flags.${MODULE_ID}.targets`, coverTargets);
+	if (targets.length === 1) applySingleTargetTotalCover(config, targets[0]?.ac);
+}
+
+export function applySimpleCover5eTooltip(ac5eConfig, message) {
+	const coverTargets = foundry.utils.getProperty(message, `data.flags.${MODULE_ID}.targets`);
+	if (!Array.isArray(coverTargets)) return;
+	ac5eConfig.simpleCoverEntries = coverTargets
+		.map((target) => {
+			const cover = target.newCover ?? target.originalCover ?? 'none';
+			const bonus = COVER_BONUSES[cover];
+			if (!bonus && bonus !== null) return null;
+			const actor = fromUuidSync(target.uuid);
+			const base = Number(actor?.system?.attributes?.ac?.value);
+			if (!Number.isFinite(base)) return null;
+			return {
+			base,
+			ac: bonus === null ? TOTAL_COVER_AC : base + bonus,
+			label: game.i18n.localize(`EFFECT.DND5E.Status${cover === 'threeQuarters' ? 'ThreeQuarters' : cover[0].toUpperCase() + cover.slice(1)}Cover`),
+			};
+		})
+		.filter(Boolean);
+	if (ac5eConfig.tooltipObj?.attack) delete ac5eConfig.tooltipObj.attack;
+}
+
+export function applySimpleCover5eDialogTooltip(ac5eConfig, message, root) {
+	const selectedCovers = new Map(
+		[...root?.querySelectorAll?.(`select[name^="${MODULE_ID}.targets."][name$=".newCover"]`) ?? []].map((select) => [
+			Number(select.name.match(/\.targets\.(\d+)\.newCover$/)?.[1]),
+			select.value,
+		]),
+	);
+	const coverTargets = foundry.utils.getProperty(message, `data.flags.${MODULE_ID}.targets`);
+	if (!Array.isArray(coverTargets)) return false;
+	const previous = coverTargets.map((target, index) => target?.newCover);
+	for (const [index, cover] of selectedCovers) {
+		if (coverTargets[index] && Object.hasOwn(COVER_BONUSES, cover)) coverTargets[index].newCover = cover === coverTargets[index].originalCover ? null : cover;
+	}
+	applySimpleCover5eTooltip(ac5eConfig, message);
+	for (const [index, cover] of selectedCovers) {
+		if (coverTargets[index]) coverTargets[index].newCover = previous[index];
+	}
+	return true;
+}
+
+export function applySimpleCover5eBuildOverride(ac5eConfig, rollConfig, message, formData, app) {
+	if (_activeModule('midi-qol') || !game.modules.get(MODULE_ID)?.api?.getLibraryMode?.()) return false;
+	const coverMessage = app?.message ?? message;
+	if (!coverMessage) return false;
+	const coverTargets = foundry.utils.getProperty(coverMessage, `data.flags.${MODULE_ID}.targets`);
+	if (!Array.isArray(coverTargets) || !coverTargets.length) return false;
+	const values = foundry.utils.flattenObject(formData?.object ?? {});
+	const targets = ac5eConfig?.options?.targets;
+	if (!Array.isArray(targets) || !targets.length) return false;
+	for (const [index, coverTarget] of coverTargets.entries()) {
+		const selected = values[`${MODULE_ID}.targets.${index}.newCover`];
+		if (selected && Object.hasOwn(COVER_BONUSES, selected)) coverTarget.newCover = selected === coverTarget.originalCover ? null : selected;
+		const cover = coverTarget.newCover ?? coverTarget.originalCover ?? 'none';
+		const bonus = COVER_BONUSES[cover];
+		const target = targets.find((entry) => entry?.tokenUuid === coverTarget.tokenUuid || entry?.uuid === coverTarget.uuid);
+		const actor = fromUuidSync(coverTarget.uuid);
+		if (!target || !actor) continue;
+		const ac = bonus === null ? TOTAL_COVER_AC : Number(actor.system?.attributes?.ac?.value ?? 0) + bonus;
+		target.ac = ac;
+		setMessageTargetAC(coverMessage, actor.uuid, ac);
+	}
+	const activeTargets = targets.filter((target) => Number.isFinite(Number(target?.ac)));
+	if (targets.length === 1 && Number(targets[0]?.ac) === TOTAL_COVER_AC) {
+		applySingleTargetTotalCover(rollConfig, TOTAL_COVER_AC);
+		return true;
+	}
+	if (!activeTargets.length) return false;
+	const baseline = Math.min(...activeTargets.map((target) => Number(target.ac)));
+	ac5eConfig.preAC5eConfig ??= {};
+	ac5eConfig.preAC5eConfig.baseRoll0Options ??= {};
+	ac5eConfig.preAC5eConfig.baseRoll0Options.target = baseline;
+	for (const entry of Object.values(ac5eConfig.preAC5eConfig.baseTargetAcByKey ?? {})) {
+		const target = targets.find((candidate) => candidate?.uuid === entry.uuid || candidate?.tokenUuid === entry.tokenUuid);
+		if (target) entry.ac = target.ac;
+	}
+	delete ac5eConfig.initialTargetADCs;
+	delete ac5eConfig.alteredTargetADCs;
+	return false;
+}
+
+export function applySimpleCover5eSingleTargetTotalCover(config, message, targets) {
+	if (_activeModule('midi-qol') || !game.modules.get(MODULE_ID)?.api?.getLibraryMode?.()) return false;
+	if (!config || !Array.isArray(targets) || targets.length !== 1) return false;
+	const coverTargets = foundry.utils.getProperty(message, `data.flags.${MODULE_ID}.targets`);
+	const target = targets[0];
+	const totalCover = coverTargets?.some((entry) =>
+		(entry?.tokenUuid === target?.tokenUuid || entry?.uuid === target?.uuid) && (entry.newCover ?? entry.originalCover) === 'total',
+	);
+	if (!totalCover) return false;
+	target.ac = TOTAL_COVER_AC;
+	setMessageTargetAC(message, target.uuid, TOTAL_COVER_AC);
+	applySingleTargetTotalCover(config, TOTAL_COVER_AC);
+	return true;
+}
+
+function applySingleTargetTotalCover(config, ac) {
+	if (Number(ac) !== TOTAL_COVER_AC) {
+		if (config) config.target = ac ?? null;
+		return;
+	}
+	config.target = TOTAL_COVER_AC;
+	for (const roll of config.rolls ?? []) {
+		roll.target = TOTAL_COVER_AC;
+		roll.options ??= {};
+		roll.options.target = TOTAL_COVER_AC;
+		roll.options.criticalSuccess = 21;
+	}
+	config.options ??= {};
+	config.options.target = TOTAL_COVER_AC;
+	config.options.criticalSuccess = 21;
+}
+
+function setMessageTargetAC(message, uuid, ac) {
+	const targets = foundry.utils.getProperty(message, 'data.flags.dnd5e.targets');
+	if (!Array.isArray(targets)) return;
+	for (const target of targets) {
+		if (target?.uuid === uuid) target.ac = ac;
+	}
+}
+
+function _activeModule(moduleId) {
+	return !!game.modules.get(moduleId)?.active;
+}


### PR DESCRIPTION
- Closes #648 
- Closes #702 
- Stops `damage.bonus` flags from working on Healing activities if `isHeal` is not added as a condition
- Fix for empty `effect.statuses` throwing `riderStatuses`